### PR TITLE
feat: add option cmd to serve builder to allow overriding the go binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ Serves the application using the `go run` command.
 nx serve api
 ```
 
+#### Watch mode
+
+To run the application in watch mode you can use `gow`, after [installing](https://github.com/mitranim/gow#installation) it on your machine.
+
+Find the key `projects.<app-name>.architect.serve.options` and set the `cmd` parameter to `gow`, like so:
+
+```json
+{
+  "projects": {
+    "api": {
+      "architect": {
+        "serve": {
+          "builder": "@nx-go/nx-go:serve",
+          "options": {
+            "cmd": "gow",
+            "main": "apps/api/src/main.go"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Testing the application
 
 Test the application using the `go test` command.

--- a/packages/nx-go/src/builders/serve/builder.spec.ts
+++ b/packages/nx-go/src/builders/serve/builder.spec.ts
@@ -2,9 +2,9 @@ import { Architect } from '@angular-devkit/architect'
 import { TestingArchitectHost } from '@angular-devkit/architect/testing'
 import { schema } from '@angular-devkit/core'
 import { join } from 'path'
-import { BuildBuilderSchema } from './schema'
+import { ServeBuilderSchema } from './schema'
 
-const options: BuildBuilderSchema = {}
+const options: ServeBuilderSchema = {}
 
 describe('Command Runner Builder', () => {
   let architect: Architect

--- a/packages/nx-go/src/builders/serve/builder.ts
+++ b/packages/nx-go/src/builders/serve/builder.ts
@@ -1,15 +1,15 @@
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect'
 import { from, Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { BuildBuilderSchema } from './schema'
+import { ServeBuilderSchema } from './schema'
 import { runGoCommand } from '../../utils/go-utils'
 
-export function runBuilder(options: BuildBuilderSchema, context: BuilderContext): Observable<BuilderOutput> {
+export function runBuilder(options: ServeBuilderSchema, context: BuilderContext): Observable<BuilderOutput> {
   return from(context.getProjectMetadata(context?.target?.project)).pipe(
     map(() => {
       const mainFile = `${options.main}`
 
-      return runGoCommand(context, 'run', [mainFile])
+      return runGoCommand(context, 'run', [mainFile], { cmd: options.cmd })
     }),
   )
 }

--- a/packages/nx-go/src/builders/serve/schema.d.ts
+++ b/packages/nx-go/src/builders/serve/schema.d.ts
@@ -1,6 +1,7 @@
 import { JsonObject } from '@angular-devkit/core'
 
-export interface BuildBuilderSchema extends JsonObject {
-  outputPath: string
+export interface ServeBuilderSchema extends JsonObject {
+  cmd: string
   main: string
+  outputPath: string
 }

--- a/packages/nx-go/src/utils/go-utils.ts
+++ b/packages/nx-go/src/utils/go-utils.ts
@@ -5,16 +5,21 @@ export function runGoCommand(
   context: BuilderContext,
   command: 'build' | 'fmt' | 'run' | 'test',
   params: string[],
-  cwd?: string,
+  options: { cwd?: string; cmd?: string } = {},
 ): { success: boolean } {
-  const cmd = `go ${command} ${params.join(' ')}`
-  cwd = cwd || process.cwd()
+  // Take the parameters or set defaults
+  const cmd = options.cmd || 'go'
+  const cwd = options.cwd || process.cwd()
+
+  // Create the command to execute
+  const execute = `${cmd} ${command} ${params.join(' ')}`
+
   try {
-    context.logger.info(`Executing command: ${cmd}`)
-    execSync(cmd, { cwd, stdio: [0, 1, 2] })
+    context.logger.info(`Executing command: ${execute}`)
+    execSync(execute, { cwd, stdio: [0, 1, 2] })
     return { success: true }
   } catch (e) {
-    context.logger.error(`Failed to execute command: ${cmd}`, e)
+    context.logger.error(`Failed to execute command: ${execute}`, e)
     return { success: false }
   }
 }


### PR DESCRIPTION
This PR adds support for overriding the `go` binary in the `serve` builder. This allows for running the application in watch mode when using a tool like [gow](https://github.com/mitranim/gow).

