### PR TITLE
Add package graph support

### DIFF
--- a/e2e/nx-go-e2e/tests/nx-go.spec.ts
+++ b/e2e/nx-go-e2e/tests/nx-go.spec.ts
@@ -95,13 +95,14 @@ describe('go-package-graph', () => {
       }`,
     )
 
-    const { stdout } = await runNxCommandAsync('print-affected')
-    const { projectGraph } = JSON.parse(stdout)
-    expect(projectGraph).toBeDefined()
-    expect(projectGraph.dependencies).toBeDefined()
-    expect(projectGraph.dependencies[appName]).toBeDefined()
+    await runNxCommandAsync('dep-graph --file=output.json')
+    
+    const { graph } = readJson('output.json')
+    expect(graph).toBeDefined()
+    expect(graph.dependencies).toBeDefined()
+    expect(graph.dependencies[appName]).toBeDefined()
 
-    const appDependencies = projectGraph.dependencies[appName]
+    const appDependencies = graph.dependencies[appName]
     expect(appDependencies.length).toBe(1)
     expect(appDependencies[0].target).toBe(libName)
   })

--- a/e2e/nx-go-e2e/utils/folder.ts
+++ b/e2e/nx-go-e2e/utils/folder.ts
@@ -1,0 +1,38 @@
+import { directoryExists } from '@nrwl/nx-plugin/testing'
+import { copyFileSync, mkdirSync, readdirSync, statSync, unlink, unlinkSync } from 'fs'
+import { join } from 'path'
+
+export const replaceFolder = (src: string, dest: string) => {
+  if (directoryExists(dest)) {
+    removeDirectory(dest)
+  }
+  copyDirectory(src, dest)
+}
+
+const removeDirectory = (dirPath: string) => {
+  const names = readdirSync(dirPath)
+  for (const name of names) {
+    const fpath = join(dirPath, name)
+    const stat = statSync(fpath)
+    if (stat.isDirectory()) {
+      removeDirectory(fpath)
+    } else {
+      unlinkSync(fpath)
+    }
+  }
+  unlinkSync(dirPath)
+}
+
+const copyDirectory = (src: string, dest: string) => {
+  mkdirSync(dest)
+  const names = readdirSync(src)
+  for (const name of names) {
+    const srcPath = join(src, name)
+    const stat = statSync(srcPath)
+    if (stat.isDirectory()) {
+      copyDirectory(srcPath, join(dest, name))
+    } else {
+      copyFileSync(srcPath, join(dest, name))
+    }
+  }
+}

--- a/packages/nx-go/generators.json
+++ b/packages/nx-go/generators.json
@@ -14,6 +14,11 @@
       "factory": "./src/generators/library/generator",
       "schema": "./src/generators/library/schema.json",
       "description": "library generator"
+    },
+    "setup-nx-go-plugin": {
+      "factory": "./src/generators/setup-nx-go-plugin/generator",
+      "schema": "./src/generators/setup-nx-go-plugin/schema.json",
+      "description": "Adds nx-go as dependency graph plugin"
     }
   }
 }

--- a/packages/nx-go/src/generators/setup-nx-go-plugin/generator.spec.ts
+++ b/packages/nx-go/src/generators/setup-nx-go-plugin/generator.spec.ts
@@ -1,0 +1,44 @@
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing'
+import { Tree, readWorkspaceConfiguration, updateWorkspaceConfiguration } from '@nrwl/devkit'
+
+import generator from './generator'
+
+describe('setup-nx-go-plugin generator', () => {
+  let appTree: Tree
+
+  beforeEach(() => {
+    appTree = createTreeWithEmptyWorkspace()
+  })
+
+  it('should run successfully', async () => {
+    await generator(appTree)
+    const config = readWorkspaceConfiguration(appTree)
+    expect(config.plugins).toBeDefined()
+    expect(config.plugins.length).toBe(1)
+    expect(config.plugins[0]).toBe('@nx-go/nx-go')
+  })
+
+  it('should merge correctly', async () => {
+    let config = readWorkspaceConfiguration(appTree)
+    config.plugins = ['fake-plugin']
+    updateWorkspaceConfiguration(appTree, config)
+
+    await generator(appTree)
+    config = readWorkspaceConfiguration(appTree)
+    expect(config.plugins).toBeDefined()
+    expect(config.plugins.length).toBe(2)
+    expect(config.plugins[1]).toBe('@nx-go/nx-go')
+  })
+
+  it('should do nothing when already defined', async () => {
+    let config = readWorkspaceConfiguration(appTree)
+    config.plugins = ['@nx-go/nx-go']
+    updateWorkspaceConfiguration(appTree, config)
+
+    await generator(appTree)
+    config = readWorkspaceConfiguration(appTree)
+    expect(config.plugins).toBeDefined()
+    expect(config.plugins.length).toBe(1)
+    expect(config.plugins[0]).toBe('@nx-go/nx-go')
+  })
+})

--- a/packages/nx-go/src/generators/setup-nx-go-plugin/generator.ts
+++ b/packages/nx-go/src/generators/setup-nx-go-plugin/generator.ts
@@ -1,0 +1,15 @@
+import { formatFiles, readWorkspaceConfiguration, Tree, updateWorkspaceConfiguration } from '@nrwl/devkit'
+
+export default async function (tree: Tree) {
+  const workspaceConfig = readWorkspaceConfiguration(tree)
+  if (workspaceConfig.plugins?.includes('@nx-go/nx-go')) {
+    return
+  }
+  if (workspaceConfig.plugins) {
+    workspaceConfig.plugins.push('@nx-go/nx-go')
+  } else {
+    workspaceConfig.plugins = ['@nx-go/nx-go']
+  }
+  updateWorkspaceConfiguration(tree, workspaceConfig)
+  await formatFiles(tree)
+}

--- a/packages/nx-go/src/generators/setup-nx-go-plugin/schema.d.ts
+++ b/packages/nx-go/src/generators/setup-nx-go-plugin/schema.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SetupNxGoPluginGeneratorSchema {}

--- a/packages/nx-go/src/generators/setup-nx-go-plugin/schema.json
+++ b/packages/nx-go/src/generators/setup-nx-go-plugin/schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "SetupNxGoPlugin",
+  "title": "",
+  "type": "object",
+  "properties": {},
+  "required": []
+}

--- a/packages/nx-go/src/go-package-graph/index.ts
+++ b/packages/nx-go/src/go-package-graph/index.ts
@@ -1,5 +1,5 @@
 import { ProjectGraph, ProjectGraphBuilder, ProjectGraphProcessorContext } from '@nrwl/devkit'
-import { extname } from 'path'
+import { basename, extname } from 'path'
 import { execSync } from 'child_process'
 
 export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphProcessorContext) => {
@@ -35,15 +35,16 @@ export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphPr
 const getGoDependencies = (projectRootLookup: Map<string, string>, file: string) => {
   const goPackageDataJson = execSync('go list -json ./' + file, { encoding: 'utf-8' })
   const goPackage: GoPackage = JSON.parse(goPackageDataJson)
+  const isTestFile = basename(file, '.go').endsWith('_test')
 
-  // Collect both package dependencies and test dependencies for accurate dependency
-  // tracking.
-  const listOfImports = [...(goPackage.Deps ?? []), ...(goPackage.TestImports ?? [])]
+  // Use the correct imports list depending if the file is a test file.
+  const listOfImports = (!isTestFile ? goPackage.Imports : goPackage.TestImports) ?? []
 
   return listOfImports
     .filter((d) => d.startsWith(goPackage.Module.Path))
     .map((d) => d.substring(goPackage.Module.Path.length + 1))
     .map((rootDir) => projectRootLookup.get(rootDir))
+    .filter((projectName) => projectName)
 }
 
 /**
@@ -54,5 +55,6 @@ interface GoPackage {
   Module: {
     Path: string
   }
+  Imports?: string[]
   TestImports?: string[]
 }

--- a/packages/nx-go/src/go-package-graph/index.ts
+++ b/packages/nx-go/src/go-package-graph/index.ts
@@ -1,0 +1,58 @@
+import { ProjectGraph, ProjectGraphBuilder, ProjectGraphProcessorContext } from '@nrwl/devkit'
+import { extname } from 'path'
+import { execSync } from 'child_process'
+
+export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphProcessorContext) => {
+  const projectRootLookupMap: Map<string, string> = new Map()
+  for (const projectName in graph.nodes) {
+    projectRootLookupMap.set(graph.nodes[projectName].data.root, projectName)
+  }
+
+  const builder = new ProjectGraphBuilder(graph)
+  // Define dependencies using the context of files that were changed to minimize work
+  // between each run.
+  for (const projectName in context.filesToProcess) {
+    context.filesToProcess[projectName]
+      .filter((f) => extname(f.file) === '.go')
+      .map(({ file }) => ({ projectName, file, dependencies: getGoDependencies(projectRootLookupMap, file) }))
+      .filter((data) => data.dependencies && data.dependencies.length > 0)
+      .forEach(({ projectName, file, dependencies }) => {
+        for (const dependency of dependencies) {
+          builder.addExplicitDependency(projectName, file, dependency)
+        }
+      })
+  }
+
+  return builder.getUpdatedProjectGraph()
+}
+
+/**
+ * getGoDependencies will use `go list` to get dependency information from a go file
+ * @param projectRootLookup
+ * @param file
+ * @returns
+ */
+const getGoDependencies = (projectRootLookup: Map<string, string>, file: string) => {
+  const goPackageDataJson = execSync('go list -json ./' + file, { encoding: 'utf-8' })
+  const goPackage: GoPackage = JSON.parse(goPackageDataJson)
+
+  // Collect both package dependencies and test dependencies for accurate dependency
+  // tracking.
+  const listOfImports = [...(goPackage.Deps ?? []), ...(goPackage.TestImports ?? [])]
+
+  return listOfImports
+    .filter((d) => d.startsWith(goPackage.Module.Path))
+    .map((d) => d.substring(goPackage.Module.Path.length + 1))
+    .map((rootDir) => projectRootLookup.get(rootDir))
+}
+
+/**
+ * GoPackage shape needed by the code
+ */
+interface GoPackage {
+  Deps?: string[]
+  Module: {
+    Path: string
+  }
+  TestImports?: string[]
+}

--- a/packages/nx-go/src/index.ts
+++ b/packages/nx-go/src/index.ts
@@ -1,0 +1,1 @@
+export { processProjectGraph } from './go-package-graph'


### PR DESCRIPTION
Implements the graph plugin so that go projects can properly relate to each other in the Nx workspace.

Currently added a generator to setup the plugin so that users can opt-in. We can execute the generator logic when application or library generators are executed if we want to for an automatic approach.

Will add e2e testing to make sure the graph logic behaves correctly but wanted to create the request to start the review.

Closes #14.