### PR TITLE
Fixed command failed when running in graph daemon

### DIFF
--- a/packages/nx-go/src/go-package-graph/index.ts
+++ b/packages/nx-go/src/go-package-graph/index.ts
@@ -1,8 +1,11 @@
 import { ProjectGraph, ProjectGraphBuilder, ProjectGraphProcessorContext } from '@nrwl/devkit'
 import { basename, extname } from 'path'
 import { execSync } from 'child_process'
+import { findNxWorkspaceRootPath } from '../utils/find-workspace-root-path'
 
 export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphProcessorContext) => {
+  const workspaceRootPath = findNxWorkspaceRootPath()
+
   const projectRootLookupMap: Map<string, string> = new Map()
   for (const projectName in graph.nodes) {
     projectRootLookupMap.set(graph.nodes[projectName].data.root, projectName)
@@ -14,7 +17,11 @@ export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphPr
   for (const projectName in context.filesToProcess) {
     context.filesToProcess[projectName]
       .filter((f) => extname(f.file) === '.go')
-      .map(({ file }) => ({ projectName, file, dependencies: getGoDependencies(projectRootLookupMap, file) }))
+      .map(({ file }) => ({
+        projectName,
+        file,
+        dependencies: getGoDependencies(workspaceRootPath, projectRootLookupMap, file),
+      }))
       .filter((data) => data.dependencies && data.dependencies.length > 0)
       .forEach(({ projectName, file, dependencies }) => {
         for (const dependency of dependencies) {
@@ -32,8 +39,8 @@ export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphPr
  * @param file
  * @returns
  */
-const getGoDependencies = (projectRootLookup: Map<string, string>, file: string) => {
-  const goPackageDataJson = execSync('go list -json ./' + file, { encoding: 'utf-8' })
+const getGoDependencies = (workspaceRootPath: string, projectRootLookup: Map<string, string>, file: string) => {
+  const goPackageDataJson = execSync('go list -json ./' + file, { encoding: 'utf-8', cwd: workspaceRootPath })
   const goPackage: GoPackage = JSON.parse(goPackageDataJson)
   const isTestFile = basename(file, '.go').endsWith('_test')
 

--- a/packages/nx-go/src/utils/find-workspace-root-path.ts
+++ b/packages/nx-go/src/utils/find-workspace-root-path.ts
@@ -1,0 +1,20 @@
+import { dirname, join } from 'path'
+import { existsSync } from 'fs'
+/**
+ * Finds the absolute path for the root path of the workspace.
+ *
+ * This is useful when modules are executed from Nx processes in the node_modules
+ * folder like when running as a graph plugin
+ */
+export const findNxWorkspaceRootPath = () => {
+  let workingDirectory = process.cwd()
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (existsSync(join(workingDirectory, 'nx.json'))) {
+      return workingDirectory
+    } else if (workingDirectory === dirname(workingDirectory)) {
+      throw new Error('At the root of the filesystem')
+    }
+    workingDirectory = dirname(workingDirectory)
+  }
+}


### PR DESCRIPTION
Currently when the plugin runs from within the daemon that Nx runs to efficiently process changes to the dependency graph the plugin will throw an error like so in `node_modules/.cache/nx/d/daemon.log`:

```
stat /path/to/workspace/node_modules/.pnpm/@nrwl+workspace@13.8.1_95b412ae97cf96e9f43494b4913c978e/node_modules/@nrwl/workspace/src/core/project-graph/daemon/client/apps/api/main.go: directory not found
Error: Command failed: go list -json ./apps/api/main.go
stat /path/to/workspace/node_modules/.pnpm/@nrwl+workspace@13.8.1_95b412ae97cf96e9f43494b4913c978e/node_modules/@nrwl/workspace/src/core/project-graph/daemon/client/apps/api/main.go: directory not found

    at checkExecSyncError (node:child_process:828:11)
    at execSync (node:child_process:902:15)
    at getGoDependencies (/path/to/workspace/node_modules/.pnpm/@nx-go+nx-go@2.1.0/node_modules/@nx-go/nx-go/src/go-package-graph/index.js:37:60)
    at /path/to/workspace/node_modules.pnpm/@nx-go+nx-go@2.1.0/node_modules/@nx-go/nx-go/src/go-package-graph/index.js:18:68
    at Array.map (<anonymous>)
    at Object.processProjectGraph (/path/to/workspace/node_modules/.pnpm/@nx-go+nx-go@2.1.0/node_modules/@nx-go/nx-go/src/go-package-graph/index.js:18:14)
    at /path/to/workspace/node_modules/.pnpm/@nrwl+workspace@13.8.1_95b412ae97cf96e9f43494b4913c978e/node_modules/@nrwl/workspace/src/core/project-graph/build-project-graph.js:215:27
    at Array.reduce (<anonymous>)
    at updateProjectGraphWithPlugins (/path/to/workspace/node_modules/.pnpm/@nrwl+workspace@13.8.1_95b412ae97cf96e9f43494b4913c978e/node_modules/@nrwl/workspace/src/core/project-graph/build-project-graph.js:213:28)
    at /path/to/workspace/node_modules/.pnpm/@nrwl+workspace@13.8.1_95b412ae97cf96e9f43494b4913c978e/node_modules/@nrwl/workspace/src/core/project-graph/build-project-graph.js:87:19 {
  status: 1,
  signal: null,
  output: [
    null,
    '',
    'stat /path/to/workspace/node_modules/.pnpm/@nrwl+workspace@13.8.1_95b412ae97cf96e9f43494b4913c978e/node_modules/@nrwl/workspace/src/core/project-graph/daemon/client/apps/api/main.go: directory not found\n'
  ],
  pid: 1445,
  stdout: '',
  stderr: 'stat /path/to/workspace/node_modules/.pnpm/@nrwl+workspace@13.8.1_95b412ae97cf96e9f43494b4913c978e/node_modules/@nrwl/workspace/src/core/project-graph/daemon/client/apps/api/main.go: directory not found\n'
}
Failed to process the project graph with "@nx-go/nx-go". This will error in the future!
```

I have tested this with other package managers and the issue is consistent.