### PR TITLE
Fixed executor unit tests to at least pass

### DIFF
--- a/packages/nx-go/src/executors/build/executor.spec.ts
+++ b/packages/nx-go/src/executors/build/executor.spec.ts
@@ -1,9 +1,21 @@
 import executor from './executor'
 import { BuildExecutorSchema } from './schema'
 
+jest.mock('../../utils')
+import * as utils from '../../utils'
+
 const options: BuildExecutorSchema = { main: '', outputPath: '' }
 
 describe('Build Executor', () => {
+  beforeEach(async () => {
+    // Mocks the runGoCommand
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(utils as any).runGoCommand = jest.fn().mockReturnValue({
+      success: true,
+    })
+  })
+
+  afterEach(() => jest.clearAllMocks())
   it('can run', async () => {
     const output = await executor(options, null)
     expect(output.success).toBe(true)

--- a/packages/nx-go/src/executors/lint/executor.spec.ts
+++ b/packages/nx-go/src/executors/lint/executor.spec.ts
@@ -1,9 +1,22 @@
 import executor from './executor'
 import { LintExecutorSchema } from './schema'
 
+jest.mock('../../utils')
+import * as utils from '../../utils'
+
 const options: LintExecutorSchema = {}
 
 describe('Lint Executor', () => {
+  beforeEach(async () => {
+    // Mocks the runGoCommand
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(utils as any).runGoCommand = jest.fn().mockReturnValue({
+      success: true,
+    })
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
   it('can run', async () => {
     const output = await executor(options, null)
     expect(output.success).toBe(true)

--- a/packages/nx-go/src/executors/serve/executor.spec.ts
+++ b/packages/nx-go/src/executors/serve/executor.spec.ts
@@ -1,11 +1,29 @@
-import { ServeExecutorSchema } from './schema';
-import executor from './executor';
+import { ServeExecutorSchema } from './schema'
+import executor from './executor'
 
-const options: ServeExecutorSchema = {};
+jest.mock('../../utils')
+import * as utils from '../../utils'
+
+const options: ServeExecutorSchema = {
+  cmd: '',
+  cwd: '',
+  main: '',
+  outputPath: '',
+}
 
 describe('Serve Executor', () => {
+  beforeEach(async () => {
+    // Mocks the runGoCommand
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(utils as any).runGoCommand = jest.fn().mockReturnValue({
+      success: true,
+    })
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
   it('can run', async () => {
-    const output = await executor(options);
-    expect(output.success).toBe(true);
-  });
-});
+    const output = await executor(options, null)
+    expect(output.success).toBe(true)
+  })
+})

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -1,9 +1,22 @@
 import { TestExecutorSchema } from './schema'
 import executor from './executor'
 
+jest.mock('../../utils')
+import * as utils from '../../utils'
+
 const options: TestExecutorSchema = {}
 
 describe('Test Executor', () => {
+  beforeEach(async () => {
+    // Mocks the runGoCommand
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(utils as any).runGoCommand = jest.fn().mockReturnValue({
+      success: true,
+    })
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
   it('can run', async () => {
     const output = await executor(options, null)
     expect(output.success).toBe(true)


### PR DESCRIPTION
We mock the `runGoCommand` to assert that the correct function is being called.

I used the source in https://github.com/nrwl/nx/blob/master/packages/cypress/src/executors/cypress/cypress.impl.spec.ts#L37 to see how to mock the use of a function from a separate module.

Next step would be to have tests to validate the correct go command is being executed based on the inputs.
