### PR TITLE
fix: missing .exe extension of executable on windows

### DIFF
--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -4,7 +4,7 @@ import { BuildExecutorSchema } from './schema'
 
 export default async function runExecutor(options: BuildExecutorSchema, context: ExecutorContext) {
   const mainFile = `${options.main}`
-  const output = `-o ${options.outputPath}`
+  const output = `-o ${options.outputPath}${process.platform === 'win32' ? '.exe' : ''}`
 
   return runGoCommand(context, 'build', [output, mainFile])
 }


### PR DESCRIPTION
Fix for #55.

Appends **.exe** extension to `options.outputPath` if `process.platform` is **win32** else leave untouched.