### PR TITLE
Updated Application generator to ensure go.mod is added to implicit dependencies

### DIFF
--- a/packages/nx-go/migrations.json
+++ b/packages/nx-go/migrations.json
@@ -1,0 +1,10 @@
+{
+  "generators": {
+    "add-go-mod-to-implicit-deps": {
+      "version": "2.3.0",
+      "description": "add-go-mod-to-implicit-deps",
+      "cli": "nx",
+      "implementation": "./src/migrations/add-go-mod-to-implicit-deps/add-go-mod-to-implicit-deps"
+    }
+  }
+}

--- a/packages/nx-go/package.json
+++ b/packages/nx-go/package.json
@@ -11,5 +11,8 @@
   "dependencies": {
     "fs-extra": "^9.1.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "nx-migrations": {
+    "migrations": "./migrations.json"
+  }
 }

--- a/packages/nx-go/project.json
+++ b/packages/nx-go/project.json
@@ -47,6 +47,11 @@
             "input": "./packages/nx-go",
             "glob": "executors.json",
             "output": "."
+          },
+          {
+            "input": "./packages/nx-go",
+            "glob": "migrations.json",
+            "output": "."
           }
         ]
       }

--- a/packages/nx-go/src/generators/application/generator.spec.ts
+++ b/packages/nx-go/src/generators/application/generator.spec.ts
@@ -1,20 +1,35 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing'
+import { Tree, readProjectConfiguration, readWorkspaceConfiguration } from '@nrwl/devkit'
 
-import generator from './generator';
-import { ApplicationGeneratorSchema } from './schema';
+import generator from './generator'
+import { ApplicationGeneratorSchema } from './schema'
 
 describe('application generator', () => {
-  let appTree: Tree;
-  const options: ApplicationGeneratorSchema = { name: 'test' };
+  let appTree: Tree
+  const options: ApplicationGeneratorSchema = { name: 'test' }
 
   beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
-  });
+    appTree = createTreeWithEmptyWorkspace()
+  })
 
   it('should run successfully', async () => {
-    await generator(appTree, options);
-    const config = readProjectConfiguration(appTree, 'test');
-    expect(config).toBeDefined();
+    await generator(appTree, options)
+    const config = readProjectConfiguration(appTree, 'test')
+    expect(config).toBeDefined()
   })
-});
+
+  it('should add go.mod to dependencies if present', async () => {
+    await generator(appTree, options)
+    const workspaceConfig = readWorkspaceConfiguration(appTree)
+    expect(workspaceConfig.implicitDependencies).toBeDefined()
+    expect(workspaceConfig.implicitDependencies['go.mod']).toBe('*')
+  })
+
+  it('should not add go.mod to dependencies if not present', async () => {
+    await generator(appTree, { name: 'test', skipGoMod: true })
+    const workspaceConfig = readWorkspaceConfiguration(appTree)
+    if (workspaceConfig.implicitDependencies) {
+      expect(workspaceConfig.implicitDependencies['go.mod']).toBeUndefined()
+    }
+  })
+})

--- a/packages/nx-go/src/migrations/add-go-mod-to-implicit-deps/add-go-mod-to-implicit-deps.ts
+++ b/packages/nx-go/src/migrations/add-go-mod-to-implicit-deps/add-go-mod-to-implicit-deps.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Tree } from '@nrwl/devkit'
+import { ensureGoModDependency } from '../../utils/ensureGoModDependency'
+
+export default function update(host: Tree) {
+  ensureGoModDependency(host)
+}

--- a/packages/nx-go/src/utils/create-go-mod.helper.ts
+++ b/packages/nx-go/src/utils/create-go-mod.helper.ts
@@ -1,4 +1,5 @@
 import { Tree } from '@nrwl/devkit'
+import { ensureGoModDependency } from './ensureGoModDependency'
 import { NormalizedSchema } from './normalized-schema.interface'
 
 export function createGoMod(tree: Tree, options: NormalizedSchema) {
@@ -7,5 +8,6 @@ export function createGoMod(tree: Tree, options: NormalizedSchema) {
     if (!tree.exists(`${modFile}`)) {
       tree.write(`${modFile}`, `module ${options.npmScope}\n`)
     }
+    ensureGoModDependency(tree)
   }
 }

--- a/packages/nx-go/src/utils/ensureGoModDependency.ts
+++ b/packages/nx-go/src/utils/ensureGoModDependency.ts
@@ -1,0 +1,18 @@
+import { readWorkspaceConfiguration, Tree, updateWorkspaceConfiguration, WorkspaceConfiguration } from '@nrwl/devkit'
+
+/**
+ * Ensures that gp.mod is an implicit dependency so that changes to go.mod triggers
+ * projects to be flagged as affeceted
+ */
+export const ensureGoModDependency = (tree: Tree) => {
+  if (!tree.exists('go.mod')) {
+    return
+  }
+  const workspaceConfig = readWorkspaceConfiguration(tree)
+  const dependencies = workspaceConfig.implicitDependencies ?? {}
+  if (!dependencies['go.mod']) {
+    dependencies['go.mod'] = '*'
+    workspaceConfig.implicitDependencies = dependencies
+    updateWorkspaceConfiguration(tree, workspaceConfig)
+  }
+}


### PR DESCRIPTION
If the application generator is executed and the `skipGoMod` is undefined or false then we will ensure that `go.mod: "*"` is added to `implicitDependencies` in `nx.json`.

Added a migration for 2.3.0 so that when users upgrade their workspace it will add the dependency if `go.mod` exists.

Closes #52.