### PR TITLE
Enable command line arguments for serve target

### DIFF
--- a/packages/nx-go/src/executors/serve/executor.spec.ts
+++ b/packages/nx-go/src/executors/serve/executor.spec.ts
@@ -8,7 +8,7 @@ const options: ServeExecutorSchema = {
   cmd: '',
   cwd: '',
   main: '',
-  outputPath: '',
+  arguments: [],
 }
 
 describe('Serve Executor', () => {
@@ -24,6 +24,12 @@ describe('Serve Executor', () => {
 
   it('can run', async () => {
     const output = await executor(options, null)
+    expect(output.success).toBe(true)
+  })
+
+  it('can run with command line arguments', async () => {
+    const opts = { ...options, arguments: ['first', '--second', '-third'] }
+    const output = await executor(opts, null)
     expect(output.success).toBe(true)
   })
 })

--- a/packages/nx-go/src/executors/serve/executor.ts
+++ b/packages/nx-go/src/executors/serve/executor.ts
@@ -10,5 +10,5 @@ export default async function runExecutor(options: ServeExecutorSchema, context:
   // We strip the project root from the main file
   const mainFile = options.main?.replace(`${cwd}/`, '')
 
-  return runGoCommand(context, 'run', [mainFile], { cmd: options.cmd, cwd })
+  return runGoCommand(context, 'run', [mainFile, ...options.arguments], { cmd: options.cmd, cwd })
 }

--- a/packages/nx-go/src/executors/serve/schema.d.ts
+++ b/packages/nx-go/src/executors/serve/schema.d.ts
@@ -2,5 +2,5 @@ export interface ServeExecutorSchema {
   cmd: string
   cwd: string
   main: string
-  outputPath: string
+  arguments: string[]
 }

--- a/packages/nx-go/src/executors/serve/schema.json
+++ b/packages/nx-go/src/executors/serve/schema.json
@@ -2,8 +2,32 @@
   "$schema": "http://json-schema.org/schema",
   "cli": "nx",
   "title": "Serve executor",
-  "description": "",
+  "description": "Run the Go application",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "cmd": {
+      "type": "string",
+      "description": "Name of the go binary (usually 'go')",
+      "default": "go"
+    },
+    "cwd": {
+      "type": "string",
+      "description": "Working directory from which to run the application",
+      "default": ""
+    },
+    "main": {
+      "type": "string",
+      "description": "Name of the file containing the main() function",
+      "default": "main.go"
+    },
+    "arguments": {
+      "description": "Command line arguments for the application",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    }
+  },
   "required": []
 }


### PR DESCRIPTION
This feature enables users to specify extra command line arguments for the `serve` target. Beyond just `go run main.go`, we can now have invocations of the form `go run main.go subcommand -flag --double-dash-option` (as an example).

This PR also brings the `serve` executor's JSON schema in sync with its TypeScript definition. Additionally, it removes the `outputPath` field from the schema, which was not being used by this target (as there is no build output when running the application).