### PR TITLE
feat: pass environment variables and build flags to build target

### DIFF
--- a/packages/nx-go/src/executors/build/executor.spec.ts
+++ b/packages/nx-go/src/executors/build/executor.spec.ts
@@ -4,7 +4,7 @@ import { BuildExecutorSchema } from './schema'
 jest.mock('../../utils')
 import * as utils from '../../utils'
 
-const options: BuildExecutorSchema = { main: '', outputPath: '' }
+const options: BuildExecutorSchema = { main: '', outputPath: '', arguments: [] }
 
 describe('Build Executor', () => {
   beforeEach(async () => {

--- a/packages/nx-go/src/executors/build/executor.spec.ts
+++ b/packages/nx-go/src/executors/build/executor.spec.ts
@@ -4,7 +4,7 @@ import { BuildExecutorSchema } from './schema'
 jest.mock('../../utils')
 import * as utils from '../../utils'
 
-const options: BuildExecutorSchema = { main: '', outputPath: '', arguments: [] }
+const options: BuildExecutorSchema = { main: '', env: [], flags: [], outputPath: '' }
 
 describe('Build Executor', () => {
   beforeEach(async () => {

--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -6,5 +6,5 @@ export default async function runExecutor(options: BuildExecutorSchema, context:
   const mainFile = `${options.main}`
   const output = `-o ${options.outputPath}${process.platform === 'win32' ? '.exe' : ''}`
 
-  return runGoCommand(context, 'build', [output, mainFile])
+  return runGoCommand(context, 'build', [output, mainFile, ...options.arguments])
 }

--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -4,7 +4,9 @@ import { BuildExecutorSchema } from './schema'
 
 export default async function runExecutor(options: BuildExecutorSchema, context: ExecutorContext) {
   const mainFile = `${options.main}`
-  const output = `-o ${options.outputPath}${process.platform === 'win32' ? '.exe' : ''}`
+  const output = `-o ${options.outputPath}`
 
-  return runGoCommand(context, 'build', [output, mainFile, ...options.arguments])
+  const cmd = [...options.env, 'go'].join(' ')
+
+  return runGoCommand(context, 'build', [...options.flags, output, mainFile], { cmd })
 }

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -1,5 +1,6 @@
 export interface BuildExecutorSchema {
   outputPath: string
   main: string
-  arguments: string[]
+  flags: string[]
+  env: string[]
 }

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -1,4 +1,5 @@
 export interface BuildExecutorSchema {
   outputPath: string
   main: string
+  arguments: string[]
 }

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -4,6 +4,25 @@
   "title": "Build executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "outputPath": {
+      "type": "string",
+      "description": "The output path of the generated files",
+      "default": ""
+    },
+    "main": {
+      "type": "string",
+      "description": "Name of the file containing the main() function",
+      "default": "main.go"
+    },
+    "arguments": {
+      "description": "Command line arguments for the application",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    }
+  },
   "required": []
 }

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "outputPath": {
       "type": "string",
-      "description": "The output path of the generated files",
+      "description": "The output path of the resulting executable",
       "default": ""
     },
     "main": {
@@ -15,8 +15,16 @@
       "description": "Name of the file containing the main() function",
       "default": "main.go"
     },
-    "arguments": {
-      "description": "Command line arguments for the application",
+    "flags": {
+      "description": "Build flags to be passed to the go command",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "env": {
+      "description": "General-purpose environment variables to be used by the go command",
       "type": "array",
       "items": {
         "type": "string"


### PR DESCRIPTION
This PR introduces two new properties to the build target options property to pass environment variables and build flags to the `go build` command. Cross-compiling is a common usecase which requires environment variables and build flags.

Example of build target options:

```json
"build": {
  "executor": "@nx-go/nx-go:build",
  "options": {
    "outputPath": "dist/apps/lambda",
    "main": "apps/lambda/main.go",
    "env": ["GOOS=linux", "GOARCH=amd64"],
    "flags": ["-ldflags=\"-s -w\""]
  }
}
```

which will result in the command:

`GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/apps/lambda apps/lambda/main.go`