### PR TITLE
fix: dep graph working with go 1.18

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -9,15 +9,16 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x]
+        go-version: [1.17.5, 1.18.0]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Use Go 1.17.5
-        uses: actions/setup-go@v2
+      - name: Use Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17.5
+          go-version: ${{ matrix.go-version }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
Hello everyone. I know that @phillipCouto is working on this, but I found the fix a couple of days ago, but didn't have time to push it to Github. 

I think the problem is actually in Go 1.18 as it returns null for the Module, in go list -json file, as for whatever reason. So the go list -m -json should return the information we seek for now.