### PR TITLE
chore: force GOWORK to be off when processing go dependencies

### DIFF
--- a/packages/nx-go/src/go-package-graph/index.ts
+++ b/packages/nx-go/src/go-package-graph/index.ts
@@ -41,7 +41,11 @@ export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphPr
  */
 const getGoDependencies = (workspaceRootPath: string, projectRootLookup: Map<string, string>, file: string) => {
   try {
-    const goModuleJSON = execSync('go list -m -json', { encoding: 'utf-8', cwd: workspaceRootPath })
+    const goModuleJSON = execSync('go list -m -json', {
+      encoding: 'utf-8',
+      cwd: workspaceRootPath,
+      env: { GOWORK: 'off' },
+    })
     const goModule: GoModule = JSON.parse(goModuleJSON)
     const goPackageDataJson = execSync('go list -json ./' + file, { encoding: 'utf-8', cwd: workspaceRootPath })
     const goPackage: GoPackage = JSON.parse(goPackageDataJson)


### PR DESCRIPTION
Adding `GOWORK="off"` environment variable forces go1.18 module resolution in workspaces mode to behave like go1.17.

This is a simple workaround to allow the dependency graph to still be generated albeit it is the whole graph of the repository.

Users interested in the dependency graph of the modules in the go workspace could manually isolate via the interactive graph.

Should fix #66 