### PR TITLE
Reworked the dependency graph plugin to properly support go workspaces

### DIFF
--- a/packages/nx-go/src/go-package-graph/index.ts
+++ b/packages/nx-go/src/go-package-graph/index.ts
@@ -1,10 +1,11 @@
 import { ProjectGraph, ProjectGraphBuilder, ProjectGraphProcessorContext } from '@nrwl/devkit'
-import { basename, extname } from 'path'
+import { basename, dirname, extname } from 'path'
 import { execSync } from 'child_process'
 import { findNxWorkspaceRootPath } from '../utils/find-workspace-root-path'
 
 export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphProcessorContext) => {
   const workspaceRootPath = findNxWorkspaceRootPath()
+  const goModules = getGoModules(workspaceRootPath)
 
   const projectRootLookupMap: Map<string, string> = new Map()
   for (const projectName in graph.nodes) {
@@ -20,7 +21,7 @@ export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphPr
       .map(({ file }) => ({
         projectName,
         file,
-        dependencies: getGoDependencies(workspaceRootPath, projectRootLookupMap, file),
+        dependencies: getGoDependencies(workspaceRootPath, goModules, projectRootLookupMap, file),
       }))
       .filter((data) => data.dependencies && data.dependencies.length > 0)
       .forEach(({ projectName, file, dependencies }) => {
@@ -35,31 +36,88 @@ export const processProjectGraph = (graph: ProjectGraph, context: ProjectGraphPr
 
 /**
  * getGoDependencies will use `go list` to get dependency information from a go file
+ * @param workspaceRootPath
+ * @param goModules
  * @param projectRootLookup
  * @param file
  * @returns
  */
-const getGoDependencies = (workspaceRootPath: string, projectRootLookup: Map<string, string>, file: string) => {
+const getGoDependencies = (
+  workspaceRootPath: string,
+  goModules: GoModule[],
+  projectRootLookup: Map<string, string>,
+  file: string,
+) => {
   try {
-    const goModuleJSON = execSync('go list -m -json', { encoding: 'utf-8', cwd: workspaceRootPath })
-    const goModule: GoModule = JSON.parse(goModuleJSON)
     const goPackageDataJson = execSync('go list -json ./' + file, { encoding: 'utf-8', cwd: workspaceRootPath })
     const goPackage: GoPackage = JSON.parse(goPackageDataJson)
     const isTestFile = basename(file, '.go').endsWith('_test')
 
-    // Use the correct imports list depending if the file is a test file.
+    // Use the correct imports list even if the file is a test file.
     const listOfImports = (!isTestFile ? goPackage.Imports : goPackage.TestImports) ?? []
 
     return listOfImports
-      .filter((d) => d.startsWith(goModule.Path))
-      .map((d) => d.substring(goModule.Path.length + 1))
-      .map((rootDir) => projectRootLookup.get(rootDir))
+      .map((goImport) => ({ goImport, goModule: goModules.find((m) => goImport.startsWith(m.Path)) }))
+      .filter((importInfo) => importInfo.goModule)
+      .map(({ goImport, goModule }) =>
+        getProjectNameForGoImport(workspaceRootPath, goImport, goModule, projectRootLookup),
+      )
       .filter((projectName) => projectName)
   } catch (ex) {
     console.error(`Error processing ${file}`)
     console.error(ex)
     return [] // Return an empty array so that we can process other files
   }
+}
+/**
+ * Parses go modules in a way that work with Go workspaces if they are used.
+ * @param workspaceRootPath
+ */
+const getGoModules = (workspaceRootPath: string) => {
+  const goModuleJSON = execSync('go list -m -json', { encoding: 'utf-8', cwd: workspaceRootPath })
+  const modules: GoModule[] = []
+  const exp = /}\r?\n{/
+
+  let jsonString = goModuleJSON
+  let idx = jsonString.search(exp)
+  while (idx !== -1) {
+    const toParse = jsonString.substring(0, idx + 1)
+    modules.push(JSON.parse(toParse))
+    jsonString = jsonString.substring(idx + 1).trimStart()
+    idx = jsonString.search(exp)
+  }
+  modules.push(JSON.parse(jsonString))
+  // Sort and reverse the modules so when looking up a go import we will encounter the most specific path first
+  modules.sort((a, b) => a.Path.localeCompare(b.Path))
+  modules.reverse()
+  return modules
+}
+/**
+ * Gets the project name for the go import by getting the relative path for the import with in the go module system
+ * then uses that to calculate the relative path on disk and looks up which project in the workspace the import is a part
+ * of.
+ * @param workspaceRootPath
+ * @param importPath
+ * @param module
+ * @param projectRootLookup
+ */
+const getProjectNameForGoImport = (
+  workspaceRootPath: string,
+  importPath: string,
+  module: GoModule,
+  projectRootLookup: Map<string, string>,
+) => {
+  const relativeImportPath = importPath.substring(module.Path.length + 1)
+  const relativeModuleDir = module.Dir.substring(workspaceRootPath.length + 1)
+  let projectPath = relativeModuleDir ? relativeModuleDir + '/' + relativeImportPath : relativeImportPath
+  while (projectPath !== '.') {
+    const projectName = projectRootLookup.get(projectPath)
+    if (projectName) {
+      return projectName
+    }
+    projectPath = dirname(projectPath)
+  }
+  return null
 }
 
 /**
@@ -76,8 +134,5 @@ interface GoPackage {
 
 interface GoModule {
   Path: string
-  Dir?: string
-  GoMod?: string
-  GoVersion?: string
-  Main?: boolean
+  Dir: string
 }


### PR DESCRIPTION
Closes #66 

Reworked the dependency graph plugin to properly support the streaming json format from `go list -m`. Also fixed the logic to match up go imports to Nx project names.

The logic of matching a go import to an Nx project is as follows:

1. Find the go module with the closest path to the go import
2. Extract the relative path for the import from the selected go module (import may be a folder in a module)
3. Extract the relative directory path for the module in the Nx workspace
4. Apply the relative path from step 2 onto the directory path from step 3
5. Look up the project name using the relative path
6. If no project name is found then set relative path to one folder up and go back to step 5
7. Repeat steps 5 and 6 until a project name is found or we reach `.` which means we are at the root

I tested with go 1.17 using regular modules and go1.18 with modules and workspaces as well as imports that use a sub folder in a module.