### PR TITLE
Support cmd and cwd options in the build executor

### DIFF
--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -6,5 +6,5 @@ export default async function runExecutor(options: BuildExecutorSchema, context:
   const mainFile = `${options.main}`
   const output = `-o ${options.outputPath}${process.platform === 'win32' ? '.exe' : ''}`
 
-  return runGoCommand(context, 'build', [output, mainFile])
+  return runGoCommand(context, 'build', [output, mainFile], {cmd: options.cmd, cwd: options.cwd})
 }

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -1,4 +1,6 @@
 export interface BuildExecutorSchema {
   outputPath: string
   main: string
+  cmd: string
+  cwd: string
 }

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -4,6 +4,27 @@
   "title": "Build executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "cmd": {
+      "type": "string",
+      "description": "Name of the go binary (usually 'go')",
+      "default": "go"
+    },
+    "cwd": {
+      "type": "string",
+      "description": "Working directory from which to run the application",
+      "default": ""
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "The path for the build output. Will get a .exe suffix on win32",
+      "default": ""
+    },
+    "main": {
+      "type": "string",
+      "description": "Name of the file containing the main() function",
+      "default": "main.go"
+    }
+  },
   "required": []
 }


### PR DESCRIPTION
To support gow or override the architecture / platform for the build the build executor will now pass the cmd and cwd options along to `runGoCommand`

```
    "build": {
      "executor": "@nx-go/nx-go:build",
      "options": {
        "outputPath": "dist/apps/some-service",
        "cmd": "env GOOS=linux GOARCH=amd64 gow",
        "main": "apps/some-service/main.go",
      }
    },
```