### PR TITLE
feat: pass flags and environment variables to go build

### DIFF
--- a/packages/nx-go/src/executors/build/executor.spec.ts
+++ b/packages/nx-go/src/executors/build/executor.spec.ts
@@ -3,21 +3,56 @@ import { BuildExecutorSchema } from './schema'
 
 jest.mock('../../utils')
 import * as utils from '../../utils'
+import { RunGoCommand } from '../../utils'
 
-const options: BuildExecutorSchema = { main: '', outputPath: '' }
+const options: BuildExecutorSchema = {}
 
 describe('Build Executor', () => {
-  beforeEach(async () => {
-    // Mocks the runGoCommand
+  afterEach(() => jest.clearAllMocks())
+
+  it('can run', async () => {
+    const mockCommand: RunGoCommand = (ctx, command, params, options) => {
+      expect(command).toBe('build')
+      expect(params).toHaveLength(0)
+      expect(options).toBeUndefined()
+
+      return { success: true }
+    }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ;(utils as any).runGoCommand = jest.fn().mockReturnValue({
-      success: true,
-    })
+    ;(utils as any).runGoCommand = jest.fn().mockImplementation(mockCommand)
+
+    const output = await executor(options, null)
+    expect(output.success).toBe(true)
   })
 
-  afterEach(() => jest.clearAllMocks())
-  it('can run', async () => {
-    const output = await executor(options, null)
+  it('receives environment variables', async () => {
+    const mockCommand: RunGoCommand = (ctx, command, params, options) => {
+      expect(command).toBe('build')
+      expect(options.env).toBeDefined()
+      expect(options.env.GOOS).toBeDefined()
+      expect(options.env.GOOS).toEqual('windows')
+
+      return { success: true }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(utils as any).runGoCommand = jest.fn().mockImplementation(mockCommand)
+
+    const output = await executor({ env: { GOOS: 'windows' } }, null)
+    expect(output.success).toBe(true)
+  })
+
+  it('pass flags', async () => {
+    const mockCommand: RunGoCommand = (ctx, command, params) => {
+      expect(command).toBe('build')
+      expect(params).toHaveLength(1)
+      expect(params[0]).toBe('-ldflags "-s -w"')
+
+      return { success: true }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(utils as any).runGoCommand = jest.fn().mockImplementation(mockCommand)
+
+    const output = await executor({ flags: ['-ldflags "-s -w"'] }, null)
     expect(output.success).toBe(true)
   })
 })

--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -5,6 +5,18 @@ import { BuildExecutorSchema } from './schema'
 export default async function runExecutor(options: BuildExecutorSchema, context: ExecutorContext) {
   const mainFile = `${options.main}`
   const output = `-o ${options.outputPath}${process.platform === 'win32' ? '.exe' : ''}`
+  const params: string[] = []
+  if (options.outputPath) {
+    params.push(output)
+  }
+  if (options.flags) {
+    params.push(...options.flags)
+  }
+  if (options.main) {
+    params.push(mainFile)
+  }
 
-  return runGoCommand(context, 'build', [output, mainFile])
+  const commandOptions = options.env ? { env: options.env } : undefined
+
+  return runGoCommand(context, 'build', params, commandOptions)
 }

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -1,4 +1,6 @@
 export interface BuildExecutorSchema {
-  outputPath: string
-  main: string
+  outputPath?: string
+  main?: string
+  env?: { [key as string]: string }
+  flags?: string[]
 }

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -4,6 +4,31 @@
   "title": "Build executor",
   "description": "",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "outputPath": {
+      "type": "string",
+      "description": "The output path of the resulting executable",
+      "default": null
+    },
+    "main": {
+      "type": "string",
+      "description": "Path to the file containing the main() function",
+      "default": null
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": { "string": "string" },
+      "description": "Environment variables to set when running the executor",
+      "default": null
+    },
+    "flags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Flags to pass to the go compiler",
+      "default": null
+    }
+  },
   "required": []
 }

--- a/packages/nx-go/src/utils/run-go-command.helper.ts
+++ b/packages/nx-go/src/utils/run-go-command.helper.ts
@@ -1,12 +1,25 @@
 import { ExecutorContext } from '@nrwl/devkit'
 import { execSync } from 'child_process'
 
-export function runGoCommand(
+export interface RunGoCommandOptions {
+  cwd?: string
+  cmd?: string
+  env?: { [key: string]: string }
+}
+
+export type RunGoCommand = (
   context: ExecutorContext,
   command: 'build' | 'fmt' | 'run' | 'test',
   params: string[],
-  options: { cwd?: string; cmd?: string } = {},
-): { success: boolean } {
+  options: RunGoCommandOptions,
+) => { success: boolean }
+
+export const runGoCommand: RunGoCommand = (
+  context: ExecutorContext,
+  command: 'build' | 'fmt' | 'run' | 'test',
+  params: string[],
+  options: RunGoCommandOptions = {},
+) => {
   // Take the parameters or set defaults
   const cmd = options.cmd || 'go'
   const cwd = options.cwd || process.cwd()
@@ -14,9 +27,12 @@ export function runGoCommand(
   // Create the command to execute
   const execute = `${cmd} ${command} ${params.join(' ')}`
 
+  // Pass along the environment variables to the process
+  const env = options.env ? { ...process.env, ...options.env } : process.env
+
   try {
     console.log(`Executing command: ${execute}`)
-    execSync(execute, { cwd, stdio: [0, 1, 2] })
+    execSync(execute, { cwd, stdio: [0, 1, 2], env })
     return { success: true }
   } catch (e) {
     console.error(`Failed to execute command: ${execute}`, e)


### PR DESCRIPTION
A few enhancements:

1. Added OS interoperable way of passing environment variables to go build
2. Added ability to pass build flags to build executor
3. Updated executor schema to properly communicate the options and expected types
4. Expanded unit tests to validate new functionality
5. Updated executor options to properly communicate output and main are optional  

This replaces the PR #65 