### PR TITLE
support tinygo

### DIFF
--- a/docs/executors/build.md
+++ b/docs/executors/build.md
@@ -8,6 +8,10 @@ Builds a project with `go build` cli command.
 
 - (string): Path to the file containing the main() function
 
+### compiler
+
+- (string): The Go compiler to use (possible values: 'go', 'tinygo')
+
 ### outputPath
 
 - (string): The output path of the resulting executable

--- a/packages/nx-go/src/executors/build/executor.spec.ts
+++ b/packages/nx-go/src/executors/build/executor.spec.ts
@@ -41,6 +41,14 @@ describe('Build Executor', () => {
     }
   );
 
+  it('should execute build command using TinyGo compiler', async () => {
+    await executor({ ...options, compiler: 'tinygo' }, context);
+    expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
+      ['build', '-o', 'dist/apps/project', 'apps/project/main.go'],
+      expect.objectContaining({ executable: 'tinygo' })
+    );
+  });
+
   it('should execute build command with custom output path and flags', async () => {
     await executor(
       { ...options, outputPath: 'custom-path', flags: ['--flag1'] },
@@ -56,7 +64,9 @@ describe('Build Executor', () => {
     config                       | flag
     ${{ buildMode: 'c-shared' }} | ${'-buildmode=c-shared'}
   `('should add flag $flag if enabled', async ({ config, flag }) => {
-    expect((await executor({ ...options, ...config }, context)).success).toBeTruthy();
+    expect(
+      (await executor({ ...options, ...config }, context)).success
+    ).toBeTruthy();
     expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
       expect.arrayContaining([flag]),
       expect.anything()

--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -19,6 +19,7 @@ export default async function runExecutor(
   return executeCommand(buildParams(options, context), {
     cwd: context.cwd,
     env: options.env,
+    executable: buildExecutable(options.compiler),
   });
 }
 
@@ -46,3 +47,13 @@ const buildOutputPath = (projectRoot: string, customPath?: string): string => {
   const extension = process.platform === 'win32' ? '.exe' : '';
   return (customPath ?? `dist/${projectRoot}`) + extension;
 };
+
+/**
+ * Determines the executable command based on the provided compiler.
+ *
+ * @param compiler - The compiler to use, which can be either 'tinygo' or 'go'.
+ * @returns The executable command as a string, either 'tinygo' or 'go'.
+ */
+const buildExecutable = (
+  compiler: BuildExecutorSchema['compiler']
+): string | undefined => (compiler === 'tinygo' ? 'tinygo' : undefined);

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -1,5 +1,6 @@
 export interface BuildExecutorSchema {
   main: string;
+  compiler?: 'go' | 'tinygo';
   outputPath?: string;
   buildMode?: string;
   env?: { [key: string]: string };

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -13,6 +13,12 @@
       "x-completion-glob": "main.go",
       "x-priority": "important"
     },
+    "compiler": {
+      "type": "string",
+      "enum": ["go", "tinygo"],
+      "description": "The Go compiler to use",
+      "default": "go"
+    },
     "outputPath": {
       "type": "string",
       "description": "The output path of the resulting executable"


### PR DESCRIPTION
This supports a different command (like using tinygo instead of go) for the build target.

Fixes #93