### PR TITLE
Add migration for executors options

### DIFF
--- a/packages/nx-go/migrations.json
+++ b/packages/nx-go/migrations.json
@@ -9,6 +9,11 @@
       "version": "3.0.0-beta.0",
       "description": "Add Go config in shared globals",
       "implementation": "./src/migrations/update-3.0.0/add-go-config-in-shared-globals"
+    },
+    "update-executors-options": {
+      "version": "3.0.0-beta.1",
+      "description": "Update options to match new schema of executors",
+      "implementation": "./src/migrations/update-3.0.0/update-executors-options"
     }
   }
 }

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -2,8 +2,8 @@
   "version": 2,
   "outputCapture": "direct-nodejs",
   "$schema": "https://json-schema.org/schema",
-  "title": "@nx-go/nx-go:build",
-  "description": "Go build options",
+  "title": "Build executor",
+  "description": "Builds an executable using the `go build` command",
   "type": "object",
   "properties": {
     "main": {

--- a/packages/nx-go/src/executors/lint/schema.json
+++ b/packages/nx-go/src/executors/lint/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "@nx-go/nx-go:lint",
-  "description": "Go lint options",
+  "title": "Lint executor",
+  "description": "Lints Go code using the `go fmt` command",
   "type": "object",
   "properties": {
     "linter": {

--- a/packages/nx-go/src/executors/lint/schema.json
+++ b/packages/nx-go/src/executors/lint/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "Lint executor",
+  "title": "@nx-go/nx-go:lint",
   "description": "Go lint options",
   "type": "object",
   "properties": {

--- a/packages/nx-go/src/executors/serve/schema.json
+++ b/packages/nx-go/src/executors/serve/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "Serve executor",
+  "title": "@nx-go/nx-go:serve",
   "description": "Go serve options",
   "type": "object",
   "properties": {

--- a/packages/nx-go/src/executors/serve/schema.json
+++ b/packages/nx-go/src/executors/serve/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "@nx-go/nx-go:serve",
-  "description": "Go serve options",
+  "title": "Serve executor",
+  "description": "Runs a Go program using the `go run` command",
   "type": "object",
   "properties": {
     "main": {

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "@nx-go/nx-go:test",
-  "description": "Go test options",
+  "title": "Test executor",
+  "description": "Tests Go code using the `go test` command",
   "type": "object",
   "properties": {
     "skipCover": {

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/schema",
   "version": 2,
-  "title": "Test executor",
+  "title": "@nx-go/nx-go:test",
   "description": "Go test options",
   "type": "object",
   "properties": {

--- a/packages/nx-go/src/migrations/update-3.0.0/update-executors-options.spec.ts
+++ b/packages/nx-go/src/migrations/update-3.0.0/update-executors-options.spec.ts
@@ -1,0 +1,66 @@
+import * as devkit from '@nx/devkit';
+import { ProjectConfiguration, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { TargetConfiguration } from 'nx/src/config/workspace-json-project-json';
+import update from './update-executors-options';
+
+jest.mock('@nx/devkit');
+
+describe('update-executors-options migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => (tree = createTreeWithEmptyWorkspace()));
+  afterEach(() => jest.clearAllMocks());
+
+  const createProjectMapWithTarget = (target: Partial<TargetConfiguration>) =>
+    new Map([
+      ['api', { root: '', targets: { target } } as ProjectConfiguration],
+    ]);
+
+  it('should update options of @nx-go/nx-go:lint executor', async () => {
+    const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+    jest.spyOn(devkit, 'getProjects').mockReturnValue(
+      createProjectMapWithTarget({
+        executor: '@nx-go/nx-go:lint',
+        options: { linter: 'revive', args: '-config ./revive.toml' },
+      })
+    );
+    await update(tree);
+    expect(updateConfig).toHaveBeenCalledWith(tree, 'api', expect.anything());
+    expect(updateConfig.mock.calls[0][2].targets.target.options).toEqual({
+      linter: 'revive',
+      args: ['-config', './revive.toml'],
+    });
+  });
+
+  it('should update options of @nx-go/nx-go:serve executor', async () => {
+    const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+    jest.spyOn(devkit, 'getProjects').mockReturnValue(
+      createProjectMapWithTarget({
+        executor: '@nx-go/nx-go:serve',
+        options: { arguments: ['--host', '0.0.0.0'] },
+      })
+    );
+    await update(tree);
+    expect(updateConfig).toHaveBeenCalledWith(tree, 'api', expect.anything());
+    expect(updateConfig.mock.calls[0][2].targets.target.options).toEqual({
+      args: ['--host', '0.0.0.0'],
+    });
+  });
+
+  it.each`
+    executor                | options                                   | description
+    ${'@nx-go/nx-go:lint'}  | ${{ args: ['-config', './revive.toml'] }} | ${'lint executor has already new args format'}
+    ${'@nx-go/nx-go:lint'}  | ${{ linter: 'revive' }}                   | ${'lint executor does not have args option'}
+    ${'@nx-go/nx-go:lint'}  | ${null}                                   | ${'lint executor does not have option'}
+    ${'@nx-go/nx-go:serve'} | ${{ cmd: 'go' }}                          | ${'serve executor does not have arguments option'}
+    ${'@nx-go/nx-go:serve'} | ${null}                                   | ${'serve executor does not have option'}
+    ${'invalid'}            | ${{}}                                     | ${'there is no valid executor'}
+  `('should do nothing if $description', async ({ executor, options }) => {
+    jest
+      .spyOn(devkit, 'getProjects')
+      .mockReturnValue(createProjectMapWithTarget({ executor, options }));
+    await update(tree);
+    expect(devkit.updateProjectConfiguration).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx-go/src/migrations/update-3.0.0/update-executors-options.ts
+++ b/packages/nx-go/src/migrations/update-3.0.0/update-executors-options.ts
@@ -1,0 +1,51 @@
+import {
+  formatFiles,
+  getProjects,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+
+/**
+ * Update executor options to ensure a smooth transition to v3.
+ *
+ * @param tree the project tree
+ */
+export default async function update(tree: Tree) {
+  const projects = getProjects(tree);
+
+  for (const [projectName, projectConfig] of projects) {
+    let shouldUpdate = false;
+
+    if (!projectConfig.targets) continue;
+
+    for (const target of Object.values(projectConfig.targets)) {
+      // lint executor: args (string) -> args (array)
+      if (
+        target.executor === '@nx-go/nx-go:lint' &&
+        target.options &&
+        'args' in target.options &&
+        typeof target.options['args'] === 'string'
+      ) {
+        target.options['args'] = target.options['args'].split(' ');
+        shouldUpdate = true;
+      }
+
+      // serve executor: arguments (array) -> args (array)
+      if (
+        target.executor === '@nx-go/nx-go:serve' &&
+        target.options &&
+        'arguments' in target.options
+      ) {
+        target.options['args'] = target.options['arguments'];
+        delete target.options['arguments'];
+        shouldUpdate = true;
+      }
+    }
+
+    if (shouldUpdate) {
+      updateProjectConfiguration(tree, projectName, projectConfig);
+    }
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
As mentioned in #107, 3.0.0-beta.0 is missing a migration for a smooth transition of executor options. This migration will change the following options:

- **@nx-go/nx-go:lint**: transform `args` option to an array of strings
- **@nx-go/nx-go:serve**: rename option `arguments` to `args`

I hope I haven't forgotten any of the options affected.
🚀 This change will be available in the next beta version!