### PR TITLE
Add support for user-specified packages and build tags

### DIFF
--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -21,4 +21,16 @@ describe('Test Executor', () => {
     const output = await executor(options, null)
     expect(output.success).toBe(true)
   })
+
+  it('can run when given packages', async () => {
+    const localOptions = { ...options, packages: ['./apps/messaging/...', './apps/omega/star/...'] }
+    const output = await executor(localOptions, null)
+    expect(output.success).toBe(true)
+  })
+
+  it('can run when given build tags', async () => {
+    const localOptions = { ...options, tags: ['integration'] }
+    const output = await executor(localOptions, null)
+    expect(output.success).toBe(true)
+  })
 })

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -6,9 +6,15 @@ export default async function runExecutor(options: TestExecutorSchema, context: 
   const projectName = context?.projectName
   const sourceRoot = context?.workspace?.projects[projectName]?.root
   const cwd = `${sourceRoot}`
-  const sources = `-v ./...`
+
+  // strict equality with false used for backward compatibility
+  // verbose output should be the default
+  const verboseOutput = options.verbose === false ? '' : '-v'
+
+  const tags = options.tags ? `-tags=${options.tags.join(',')}` : ''
+  const sources = options.packages && options.packages.length > 0 ? `${options.packages.join(' ')}` : `./...`
   const cover = options.skipCover ? '' : '-cover'
   const race = options.skipRace ? '' : '-race'
 
-  return runGoCommand(context, 'test', [sources, cover, race], { cwd })
+  return runGoCommand(context, 'test', [verboseOutput, tags, sources, cover, race], { cwd })
 }

--- a/packages/nx-go/src/executors/test/schema.d.ts
+++ b/packages/nx-go/src/executors/test/schema.d.ts
@@ -1,4 +1,7 @@
 export interface TestExecutorSchema {
   skipCover?: boolean
   skipRace?: boolean
+  verbose?: boolean
+  packages?: string[]
+  tags?: string[]
 }


### PR DESCRIPTION
Sometimes you don't want to run all tests in a project. Sometimes you want to separate unit tests from integration tests by [using build tags](https://mickey.dev/posts/go-build-tags-testing/). Sometimes you don't want verbose output in large test suites because that makes it difficult to pinpoint the source of the failure.