### PR TITLE
Customizable packages, build tags, and verbosity for test executor

### DIFF
--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -100,7 +100,7 @@ describe('nx-go', () => {
   it('should test the application', async () => {
     const result = await runNxCommandAsync(`test ${appName} --skipRace`);
     expect(result.stdout).toContain(
-      `Executing command: go test -v ./... -cover`
+      `Executing command: go test -v -cover ./...`
     );
   });
 

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -8,7 +8,11 @@ jest.mock('../../utils', () => ({
   extractProjectRoot: jest.fn(() => 'apps/project'),
 }));
 
-const options: TestExecutorSchema = {};
+const options: TestExecutorSchema = {
+  packages: [],
+  buildTags: [],
+  verbose: true
+};
 
 const context: ExecutorContext = {
   cwd: 'current-dir',
@@ -22,7 +26,7 @@ describe('Test Executor', () => {
     const output = await executor(options, context);
     expect(output.success).toBeTruthy();
     expect(spyExecute).toHaveBeenCalledWith(
-      ['test', '-v', './...', '-cover', '-race'],
+      ['test', '-v', '', '-cover', '-race', './...'],
       { cwd: 'apps/project' }
     );
   });
@@ -37,6 +41,48 @@ describe('Test Executor', () => {
     expect(output.success).toBeTruthy();
     expect(spyExecute).toHaveBeenCalledWith(
       expect.not.arrayContaining([flag]),
+      { cwd: 'apps/project' }
+    );
+  });
+
+  it('should execute tests for specified packages', async () => {
+    const localOptions = {
+      ...options,
+      packages: ['./apps/omegastar/...', './libs/debt']
+    }
+    const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
+    const output = await executor(localOptions, context);
+    expect(output.success).toBeTruthy();
+    expect(spyExecute).toHaveBeenCalledWith(
+      ['test', '-v', '', '-cover', '-race', './apps/omegastar/... ./libs/debt'],
+      { cwd: 'apps/project' }
+    );
+  });
+
+  it('should execute tests for packages with the specified build tags', async () => {
+    const localOptions = {
+      ...options,
+      buildTags: ['integration']
+    }
+    const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
+    const output = await executor(localOptions, context);
+    expect(output.success).toBeTruthy();
+    expect(spyExecute).toHaveBeenCalledWith(
+      ['test', '-v', '-tags=integration', '-cover', '-race', './...'],
+      { cwd: 'apps/project' }
+    );
+  });
+
+  it('should not use verbose output when verbose = false', async () => {
+    const localOptions = {
+      ...options,
+      verbose: false
+    }
+    const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
+    const output = await executor(localOptions, context);
+    expect(output.success).toBeTruthy();
+    expect(spyExecute).toHaveBeenCalledWith(
+      ['test', '', '', '-cover', '-race', './...'],
       { cwd: 'apps/project' }
     );
   });

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -12,13 +12,16 @@ export default async function runExecutor(
   options: TestExecutorSchema,
   context: ExecutorContext
 ) {
+  const packages = options.packages;
+  const buildTags = options.buildTags;
   return executeCommand(
     [
       'test',
-      '-v',
-      './...',
+      options.verbose ? '-v' : '',
+      buildTags.length > 0 ? `-tags=${buildTags.join(',')}` : '',
       ...buildFlagIfNotSkipped('-cover', options.skipCover),
       ...buildFlagIfNotSkipped('-race', options.skipRace),
+      packages.length > 0 ? packages.join(' ') : './...',
     ],
     { cwd: extractProjectRoot(context) }
   );

--- a/packages/nx-go/src/executors/test/schema.d.ts
+++ b/packages/nx-go/src/executors/test/schema.d.ts
@@ -1,4 +1,7 @@
 export interface TestExecutorSchema {
   skipCover?: boolean;
   skipRace?: boolean;
+  packages: string[];
+  buildTags: string[];
+  verbose: boolean;
 }

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -14,6 +14,27 @@
       "description": "Whether or not to skip race detector during test execution",
       "type": "boolean",
       "default": false
+    },
+    "packages": {
+      "description": "Run tests only for the specified packages",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default:": []
+    },
+    "buildTags": {
+      "description": "Run tests only for packages with the specified build tags",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default:": []
+    },
+    "verbose": {
+      "description": "Whether to use verbose output for tests",
+      "type": "boolean",
+      "default": true
     }
   },
   "required": []


### PR DESCRIPTION
Oftentimes one does not want to run the entire test suite for an application because that takes too much time. It is now possible to specify that `nx test` should only run for certain packages.

Some codebases [separate unit tests from integration tests using build tags](https://mickey.dev/posts/go-build-tags-testing/). It is now possible to run tests only for packages with a given build tag.

Finally, verbose test output can sometimes make it difficult to pinpoint the source of the test failure. It can be disabled by setting `"verbose": "false"`.