### PR TITLE
Option to disable verbose test output

### DIFF
--- a/docs/executors/test.md
+++ b/docs/executors/test.md
@@ -4,10 +4,14 @@ Uses `go test` command to run tests of a Go project.
 
 ## Options
 
-### skipCover
+### cover
 
-- (boolean): Skip coverage analysis during test execution
+- (boolean): Enable coverage analysis
 
-### skipRace
+### race
 
-- (boolean): Skip race detector during test execution
+- (boolean): Enable race detector
+
+### verbose
+
+- (boolean): Enable verbose test output

--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -100,7 +100,7 @@ describe('nx-go', () => {
   it('should test the application', async () => {
     const result = await runNxCommandAsync(`test ${appName} --skipRace`);
     expect(result.stdout).toContain(
-      `Executing command: go test -v ./... -cover`
+      `Executing command: go test -v -cover ./...`
     );
   });
 

--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -98,7 +98,7 @@ describe('nx-go', () => {
   });
 
   it('should test the application', async () => {
-    const result = await runNxCommandAsync(`test ${appName} --skipRace`);
+    const result = await runNxCommandAsync(`test ${appName} --cover --verbose`);
     expect(result.stdout).toContain(
       `Executing command: go test -v -cover ./...`
     );

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -8,7 +8,9 @@ jest.mock('../../utils', () => ({
   extractProjectRoot: jest.fn(() => 'apps/project'),
 }));
 
-const options: TestExecutorSchema = {};
+const options: TestExecutorSchema = {
+  verbose: true
+};
 
 const context: ExecutorContext = {
   cwd: 'current-dir',
@@ -22,7 +24,7 @@ describe('Test Executor', () => {
     const output = await executor(options, context);
     expect(output.success).toBeTruthy();
     expect(spyExecute).toHaveBeenCalledWith(
-      ['test', '-v', './...', '-cover', '-race'],
+      ['test', '-v', '-cover', '-race', './...'],
       { cwd: 'apps/project' }
     );
   });
@@ -37,6 +39,17 @@ describe('Test Executor', () => {
     expect(output.success).toBeTruthy();
     expect(spyExecute).toHaveBeenCalledWith(
       expect.not.arrayContaining([flag]),
+      { cwd: 'apps/project' }
+    );
+  });
+
+  it('should not use the -v flag if verbose = false', async () => {
+    const localOptions = {...options, verbose: false};
+    const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
+    const output = await executor(localOptions, context);
+    expect(output.success).toBeTruthy();
+    expect(spyExecute).toHaveBeenCalledWith(
+      ['test', '', '-cover', '-race', './...'],
       { cwd: 'apps/project' }
     );
   });

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -8,9 +8,7 @@ jest.mock('../../utils', () => ({
   extractProjectRoot: jest.fn(() => 'apps/project'),
 }));
 
-const options: TestExecutorSchema = {
-  verbose: true
-};
+const options: TestExecutorSchema = {};
 
 const context: ExecutorContext = {
   cwd: 'current-dir',
@@ -23,33 +21,22 @@ describe('Test Executor', () => {
     const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
     const output = await executor(options, context);
     expect(output.success).toBeTruthy();
-    expect(spyExecute).toHaveBeenCalledWith(
-      ['test', '-v', '-cover', '-race', './...'],
-      { cwd: 'apps/project' }
-    );
+    expect(spyExecute).toHaveBeenCalledWith(['test', './...'], {
+      cwd: 'apps/project',
+    });
   });
 
   it.each`
-    config                 | flag
-    ${{ skipCover: true }} | ${'-cover'}
-    ${{ skipRace: true }}  | ${'-race'}
-  `('should remove flag $flag if skipped', async ({ config, flag }) => {
+    config               | flag
+    ${{ verbose: true }} | ${'-verbose'}
+    ${{ cover: true }}   | ${'-cover'}
+    ${{ race: true }}    | ${'-race'}
+  `('should add flag $flag if enabled', async ({ config, flag }) => {
     const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
     const output = await executor({ ...options, ...config }, context);
     expect(output.success).toBeTruthy();
     expect(spyExecute).toHaveBeenCalledWith(
       expect.not.arrayContaining([flag]),
-      { cwd: 'apps/project' }
-    );
-  });
-
-  it('should not use the -v flag if verbose = false', async () => {
-    const localOptions = {...options, verbose: false};
-    const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
-    const output = await executor(localOptions, context);
-    expect(output.success).toBeTruthy();
-    expect(spyExecute).toHaveBeenCalledWith(
-      ['test', '', '-cover', '-race', './...'],
       { cwd: 'apps/project' }
     );
   });

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -15,10 +15,10 @@ export default async function runExecutor(
   return executeCommand(
     [
       'test',
-      '-v',
-      './...',
+      options.verbose ? '-v' : '',
       ...buildFlagIfNotSkipped('-cover', options.skipCover),
       ...buildFlagIfNotSkipped('-race', options.skipRace),
+      './...',
     ],
     { cwd: extractProjectRoot(context) }
   );

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -15,15 +15,15 @@ export default async function runExecutor(
   return executeCommand(
     [
       'test',
-      options.verbose ? '-v' : '',
-      ...buildFlagIfNotSkipped('-cover', options.skipCover),
-      ...buildFlagIfNotSkipped('-race', options.skipRace),
+      ...buildFlagIfEnabled('-v', options.verbose),
+      ...buildFlagIfEnabled('-cover', options.cover),
+      ...buildFlagIfEnabled('-race', options.race),
       './...',
     ],
     { cwd: extractProjectRoot(context) }
   );
 }
 
-const buildFlagIfNotSkipped = (flag: string, skipped: boolean): string[] => {
-  return skipped ? [] : [flag];
+const buildFlagIfEnabled = (flag: string, enabled: boolean): string[] => {
+  return enabled ? [flag] : [];
 };

--- a/packages/nx-go/src/executors/test/schema.d.ts
+++ b/packages/nx-go/src/executors/test/schema.d.ts
@@ -1,4 +1,5 @@
 export interface TestExecutorSchema {
   skipCover?: boolean;
   skipRace?: boolean;
+  verbose: boolean;
 }

--- a/packages/nx-go/src/executors/test/schema.d.ts
+++ b/packages/nx-go/src/executors/test/schema.d.ts
@@ -1,5 +1,5 @@
 export interface TestExecutorSchema {
-  skipCover?: boolean;
-  skipRace?: boolean;
-  verbose: boolean;
+  cover?: boolean;
+  race?: boolean;
+  verbose?: boolean;
 }

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -5,20 +5,20 @@
   "description": "Tests Go code using the `go test` command",
   "type": "object",
   "properties": {
-    "skipCover": {
-      "description": "Whether or not to skip coverage analysis during test execution",
+    "cover": {
+      "description": "Whether to enable coverage analysis",
       "type": "boolean",
       "default": false
     },
-    "skipRace": {
-      "description": "Whether or not to skip race detector during test execution",
+    "race": {
+      "description": "Whether to enable race detector",
       "type": "boolean",
       "default": false
     },
     "verbose": {
       "description": "Whether to enable verbose test output",
       "type": "boolean",
-      "default": true
+      "default": false
     }
   },
   "required": []

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -14,6 +14,11 @@
       "description": "Whether or not to skip race detector during test execution",
       "type": "boolean",
       "default": false
+    },
+    "verbose": {
+      "description": "Whether to enable verbose test output",
+      "type": "boolean",
+      "default": true
     }
   },
   "required": []

--- a/packages/nx-go/src/migrations/update-3.0.0/update-executors-options.ts
+++ b/packages/nx-go/src/migrations/update-3.0.0/update-executors-options.ts
@@ -40,6 +40,20 @@ export default async function update(tree: Tree) {
         delete target.options['arguments'];
         shouldUpdate = true;
       }
+
+      // test executor: skipCover -> cover ; skipRace -> race ; add verbose
+      if (target.executor === '@nx-go/nx-go:test') {
+        target.options ??= {};
+        const oldOptions = Object.assign({}, target.options);
+
+        toggleOption(target.options, 'skipCover', 'cover');
+        toggleOption(target.options, 'skipRace', 'race');
+        target.options['verbose'] = true;
+
+        if (JSON.stringify(oldOptions) !== JSON.stringify(target.options)) {
+          shouldUpdate = true;
+        }
+      }
     }
 
     if (shouldUpdate) {
@@ -49,3 +63,12 @@ export default async function update(tree: Tree) {
 
   await formatFiles(tree);
 }
+
+const toggleOption = (options: object, skipName: string, name: string) => {
+  if (skipName in options && options[skipName]) {
+    delete options[name];
+  } else {
+    options[name] = true;
+  }
+  delete options[skipName];
+};


### PR DESCRIPTION
In large test suites, verbose test output can make it difficult to pinpoint failing tests.

This PR adds an option to the test executor to disable verbose test output. It defaults to "true" for backward compatibility.