### PR TITLE
Add coverProfile to test executor

### DIFF
--- a/docs/executors/test.md
+++ b/docs/executors/test.md
@@ -8,6 +8,10 @@ Uses `go test` command to run tests of a Go project.
 
 - (boolean): Enable coverage analysis
 
+### coverProfile
+
+- (string): Write a coverage profile to the file after all tests have passed
+
 ### race
 
 - (boolean): Enable race detector

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -1,7 +1,7 @@
-import { ExecutorContext } from '@nx/devkit';
+import type { ExecutorContext } from '@nx/devkit';
 import * as commonFunctions from '../../utils';
 import executor from './executor';
-import { TestExecutorSchema } from './schema';
+import type { TestExecutorSchema } from './schema';
 
 jest.mock('../../utils', () => ({
   executeCommand: jest.fn().mockResolvedValue({ success: true }),
@@ -27,10 +27,11 @@ describe('Test Executor', () => {
   });
 
   it.each`
-    config               | flag
-    ${{ verbose: true }} | ${'-verbose'}
-    ${{ cover: true }}   | ${'-cover'}
-    ${{ race: true }}    | ${'-race'}
+    config                              | flag
+    ${{ verbose: true }}                | ${'-verbose'}
+    ${{ cover: true }}                  | ${'-cover'}
+    ${{ coverProfile: 'coverage.out' }} | ${'-coverageprofile=coverage.out'}
+    ${{ race: true }}                   | ${'-race'}
   `('should add flag $flag if enabled', async ({ config, flag }) => {
     const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
     const output = await executor({ ...options, ...config }, context);

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -1,6 +1,6 @@
-import { ExecutorContext } from '@nx/devkit';
+import type { ExecutorContext } from '@nx/devkit';
 import { executeCommand, extractProjectRoot } from '../../utils';
-import { TestExecutorSchema } from './schema';
+import type { TestExecutorSchema } from './schema';
 
 /**
  * This executor tests Go code using the `go test` command.
@@ -17,6 +17,7 @@ export default async function runExecutor(
       'test',
       ...buildFlagIfEnabled('-v', options.verbose),
       ...buildFlagIfEnabled('-cover', options.cover),
+      ...buildStringFlagIfValid(`-coverprofile`, options.coverProfile),
       ...buildFlagIfEnabled('-race', options.race),
       './...',
     ],
@@ -26,4 +27,8 @@ export default async function runExecutor(
 
 const buildFlagIfEnabled = (flag: string, enabled: boolean): string[] => {
   return enabled ? [flag] : [];
+};
+
+const buildStringFlagIfValid = (flag: string, value?: string): string[] => {
+  return value ? [`${flag}=${value}`] : [];
 };

--- a/packages/nx-go/src/executors/test/schema.d.ts
+++ b/packages/nx-go/src/executors/test/schema.d.ts
@@ -1,5 +1,6 @@
 export interface TestExecutorSchema {
   cover?: boolean;
+  coverProfile?: string;
   race?: boolean;
   verbose?: boolean;
 }

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -10,6 +10,11 @@
       "type": "boolean",
       "default": false
     },
+    "coverProfile": {
+      "description": "Write a coverage profile to the file after all tests have passed",
+      "type": "string",
+      "x-completion-type": "file"
+    },
     "race": {
       "description": "Whether to enable race detector",
       "type": "boolean",


### PR DESCRIPTION
This PR adds the "coverProfile" property to the test executor, in order to save the cover in a file (as described [here](https://pkg.go.dev/cmd/go/internal/test) in the Go documentation).

Closes #45 