### PR TITLE
Add run property to test executor

### DIFF
--- a/docs/executors/test.md
+++ b/docs/executors/test.md
@@ -16,6 +16,10 @@ Uses `go test` command to run tests of a Go project.
 
 - (boolean): Enable race detector
 
+### run
+
+- (string): Run only tests matching this regular expression
+
 ### verbose
 
 - (boolean): Enable verbose test output

--- a/packages/nx-go-e2e/shared/create-test-project.ts
+++ b/packages/nx-go-e2e/shared/create-test-project.ts
@@ -1,14 +1,15 @@
 import { joinPathFragments, readJsonFile, workspaceRoot } from '@nx/devkit';
+import { tmpProjPath } from '@nx/plugin/testing';
 import { execSync } from 'child_process';
 import { mkdirSync, rmSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 
 /**
  * Creates a test project with create-nx-workspace and installs the plugin
  */
-export default function createTestProject(preset = 'apps') {
+export default function createTestProject(preset = 'apps'): string {
   const projectName = 'proj';
-  const projectDirectory = join(process.cwd(), 'tmp', 'nx-e2e', projectName);
+  const projectDirectory = tmpProjPath();
 
   // Ensure projectDirectory is empty
   rmSync(projectDirectory, { recursive: true, force: true });

--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -2,7 +2,7 @@ import {
   checkFilesExist,
   readFile,
   readJson,
-  runCommandAsync,
+  runNxCommandAsync,
   uniq,
   updateFile,
 } from '@nx/plugin/testing';
@@ -32,10 +32,6 @@ describe('nx-go', () => {
   afterAll(() => {
     rmSync(projectDirectory, { recursive: true, force: true });
   });
-
-  async function runNxCommandAsync(command: string) {
-    return runCommandAsync(`nx ${command}`, { cwd: projectDirectory });
-  }
 
   it('should be installed', () => {
     // npm ls will fail if the package is not installed properly

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -28,17 +28,17 @@ describe('Test Executor', () => {
 
   it.each`
     config                              | flag
-    ${{ verbose: true }}                | ${'-verbose'}
+    ${{ verbose: true }}                | ${'-v'}
     ${{ cover: true }}                  | ${'-cover'}
-    ${{ coverProfile: 'coverage.out' }} | ${'-coverageprofile=coverage.out'}
+    ${{ coverProfile: 'coverage.out' }} | ${'-coverprofile=coverage.out'}
     ${{ race: true }}                   | ${'-race'}
+    ${{ run: 'TestProjection' }}        | ${'-run=TestProjection'}
   `('should add flag $flag if enabled', async ({ config, flag }) => {
     const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
     const output = await executor({ ...options, ...config }, context);
     expect(output.success).toBeTruthy();
-    expect(spyExecute).toHaveBeenCalledWith(
-      expect.not.arrayContaining([flag]),
-      { cwd: 'apps/project' }
-    );
+    expect(spyExecute).toHaveBeenCalledWith(expect.arrayContaining([flag]), {
+      cwd: 'apps/project',
+    });
   });
 });

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -19,6 +19,7 @@ export default async function runExecutor(
       ...buildFlagIfEnabled('-cover', options.cover),
       ...buildStringFlagIfValid(`-coverprofile`, options.coverProfile),
       ...buildFlagIfEnabled('-race', options.race),
+      ...buildStringFlagIfValid(`-run`, options.run),
       './...',
     ],
     { cwd: extractProjectRoot(context) }

--- a/packages/nx-go/src/executors/test/schema.d.ts
+++ b/packages/nx-go/src/executors/test/schema.d.ts
@@ -2,5 +2,6 @@ export interface TestExecutorSchema {
   cover?: boolean;
   coverProfile?: string;
   race?: boolean;
+  run?: string;
   verbose?: boolean;
 }

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -20,6 +20,10 @@
       "type": "boolean",
       "default": false
     },
+    "run": {
+      "description": "Run only tests matching this regular expression",
+      "type": "string"
+    },
     "verbose": {
       "description": "Whether to enable verbose test output",
       "type": "boolean",


### PR DESCRIPTION
This PR adds the "run" property to the test executor, in order to only run tests matching a specified regular expression (as described [here](https://pkg.go.dev/cmd/go/internal/test) in the Go documentation).

Closes #90