### PR TITLE
Add support of Nx 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go_version: [ 1.22.0 ]
+        go_version: [ 1.22.3 ]
         node_version: [ 20.x ]
     steps:
       - name: 📥 Checkout Repo
@@ -41,7 +41,7 @@ jobs:
       - name: ⚙ Setup
         uses: ./.github/actions/setup
         with:
-          go_version: 1.22.0
+          go_version: 1.22.3
           node_version: 20.x
 
       - name: 💭 Validate current commit (last commit) with commitlint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: ⚙ Setup
         uses: ./.github/actions/setup
         with:
-          go_version: 1.22.0
+          go_version: 1.22.3
           node_version: 20.x
 
       - name: Configure Git

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Want to try out these capabilities quickly? Visit our [playground](https://githu
 
 | nx-go version | Nx version   |
 |---------------|--------------|
-| 3.x           | 17.x, 18.x   |
+| 3.x           | 17.x to 19.x |
 | 2.x           | 13.x to 16.x |
 | 1.x           | < 13.x       |
 

--- a/packages/nx-go/package.json
+++ b/packages/nx-go/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/nx-go/nx-go/issues"
   },
   "dependencies": {
-    "@nx/devkit": "^17.0.0 || ^18.0.0",
+    "@nx/devkit": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "tslib": "^2.3.0"
   },
   "type": "commonjs",


### PR DESCRIPTION
This PR adds the support of **Nx 19**. This major update does not appear to have any impact on the nx-go plugin. I've run few successful migrations. Please let me know of any problems with Nx 19 (apart from the peer dependency issue).

Note that we'll need to take an interest in [Project Crystal](https://nx.dev/concepts/inferred-tasks), as it will simplify Nx project configuration.