### PR TITLE
Do not strip away special characters from project names

### DIFF
--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -51,7 +51,7 @@ describe('nx-go', () => {
 
     expect(() => checkFilesExist(`${appName}/main.go`)).not.toThrow();
     expect(() => checkFilesExist(`${appName}/go.mod`)).not.toThrow();
-    expect(readFile(`${appName}/go.mod`)).toContain(`module proj/${appName}`);
+    expect(readFile(`${appName}/go.mod`)).toContain(`module ${appName}`);
     expect(readFile(`go.work`)).toContain(`use ./${appName}`);
   });
 
@@ -60,7 +60,7 @@ describe('nx-go', () => {
 
     expect(() => checkFilesExist(`${libName}/${libName}.go`)).not.toThrow();
     expect(() => checkFilesExist(`${libName}/go.mod`)).not.toThrow();
-    expect(readFile(`${libName}/go.mod`)).toContain(`module proj/${libName}`);
+    expect(readFile(`${libName}/go.mod`)).toContain(`module ${libName}`);
     expect(readFile(`go.work`)).toContain(
       `use (\n\t./${appName}\n\t./${libName}\n)`
     );
@@ -116,7 +116,7 @@ describe('nx-go', () => {
 
         import (
           "fmt"
-          "proj/${libName}"
+          "${libName}"
         )
 
         func main() {

--- a/packages/nx-go/src/generators/application/generator.spec.ts
+++ b/packages/nx-go/src/generators/application/generator.spec.ts
@@ -1,7 +1,7 @@
 const normalizeOptions = {
-  npmScope: 'proj',
-  moduleName: 'api',
-  projectRoot: 'apps/api',
+  name: 'my-api',
+  moduleName: 'myapi',
+  projectRoot: 'apps/my-api',
   projectType: 'application',
   parsedTags: ['api', 'backend'],
 };
@@ -35,9 +35,9 @@ describe('application generator', () => {
       tree,
       'test',
       {
-        root: 'apps/api',
+        root: 'apps/my-api',
         projectType: 'application',
-        sourceRoot: 'apps/api',
+        sourceRoot: 'apps/my-api',
         targets: defaultTargets,
         tags: ['api', 'backend'],
       }
@@ -50,7 +50,7 @@ describe('application generator', () => {
     expect(nxDevkit.generateFiles).toHaveBeenCalledWith(
       tree,
       join(__dirname, './files'),
-      'apps/api',
+      'apps/my-api',
       normalizeOptions
     );
   });
@@ -60,8 +60,8 @@ describe('application generator', () => {
     await applicationGenerator(tree, options);
     expect(shared.createGoMod).toHaveBeenCalledWith(
       tree,
-      'proj/api',
-      'apps/api'
+      'apps/my-api',
+      'apps/my-api'
     );
   });
 
@@ -72,9 +72,9 @@ describe('application generator', () => {
       tree,
       'test',
       {
-        root: 'apps/api',
+        root: 'apps/my-api',
         projectType: 'application',
-        sourceRoot: 'apps/api',
+        sourceRoot: 'apps/my-api',
         targets: {
           ...defaultTargets,
           tidy: {
@@ -94,7 +94,10 @@ describe('application generator', () => {
   it('should add Go work dependency if in a Go workspace', async () => {
     jest.spyOn(shared, 'isGoWorkspace').mockReturnValueOnce(true);
     await applicationGenerator(tree, options);
-    expect(shared.addGoWorkDependency).toHaveBeenCalledWith(tree, 'apps/api');
+    expect(shared.addGoWorkDependency).toHaveBeenCalledWith(
+      tree,
+      'apps/my-api'
+    );
   });
 
   it('should not add Go work dependency if not in a Go workspace', async () => {

--- a/packages/nx-go/src/generators/application/generator.ts
+++ b/packages/nx-go/src/generators/application/generator.ts
@@ -60,11 +60,7 @@ export default async function applicationGenerator(
   generateFiles(tree, join(__dirname, 'files'), options.projectRoot, options);
 
   if (isGoWorkspace(tree)) {
-    createGoMod(
-      tree,
-      `${options.npmScope}/${options.moduleName}`,
-      options.projectRoot
-    );
+    createGoMod(tree, options.projectRoot, options.projectRoot);
     addGoWorkDependency(tree, options.projectRoot);
     projectConfiguration.targets.tidy = {
       executor: '@nx-go/nx-go:tidy',

--- a/packages/nx-go/src/generators/library/generator.spec.ts
+++ b/packages/nx-go/src/generators/library/generator.spec.ts
@@ -1,7 +1,6 @@
 const normalizeOptions = {
   name: 'data-access',
   moduleName: 'dataaccess',
-  npmScope: 'proj',
   projectName: 'data-access',
   projectRoot: 'libs/data-access',
   projectType: 'library',
@@ -68,7 +67,7 @@ describe('library generator', () => {
     await libraryGenerator(tree, options);
     expect(shared.createGoMod).toHaveBeenCalledWith(
       tree,
-      'proj/dataaccess',
+      'libs/data-access',
       'libs/data-access'
     );
   });

--- a/packages/nx-go/src/generators/library/generator.ts
+++ b/packages/nx-go/src/generators/library/generator.ts
@@ -52,11 +52,7 @@ export default async function libraryGenerator(
   });
 
   if (isGoWorkspace(tree)) {
-    createGoMod(
-      tree,
-      `${options.npmScope}/${options.moduleName}`,
-      options.projectRoot
-    );
+    createGoMod(tree, options.projectRoot, options.projectRoot);
     addGoWorkDependency(tree, options.projectRoot);
     projectConfiguration.targets.tidy = {
       executor: '@nx-go/nx-go:tidy',

--- a/packages/nx-go/src/utils/normalize-options.spec.ts
+++ b/packages/nx-go/src/utils/normalize-options.spec.ts
@@ -16,9 +16,6 @@ jest.mock('@nx/devkit/src/generators/project-name-and-root-utils', () => ({
     projectNameAndRootFormat: 'as-provided',
   }),
 }));
-jest.mock('./npm-bridge', () => ({
-  getProjectScope: jest.fn().mockReturnValue('nx-go'),
-}));
 
 describe('normalizeOptions', () => {
   let tree: Tree;
@@ -40,16 +37,6 @@ describe('normalizeOptions', () => {
     expect(output.directory).toBe('backend-dir');
     expect(output.projectNameAndRootFormat).toBe('as-provided');
     expect(output.parsedTags).toEqual([]);
-  });
-
-  it('should extract npm scope from package.json', async () => {
-    const output = await normalizeOptions(
-      tree,
-      { name: 'backend' },
-      'application',
-      'init'
-    );
-    expect(output.npmScope).toBe('nx-go');
   });
 
   it('should normalize tags', async () => {

--- a/packages/nx-go/src/utils/normalize-options.ts
+++ b/packages/nx-go/src/utils/normalize-options.ts
@@ -3,7 +3,6 @@ import {
   determineProjectNameAndRootOptions,
   ProjectNameAndRootFormat,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
-import { getProjectScope } from './npm-bridge';
 
 export interface GeneratorSchema {
   name: string;
@@ -15,7 +14,6 @@ export interface GeneratorSchema {
 
 export interface GeneratorNormalizedSchema extends GeneratorSchema {
   moduleName: string;
-  npmScope: string;
   projectName: string;
   projectRoot: string;
   projectType: ProjectType;
@@ -41,12 +39,10 @@ export const normalizeOptions = async (
     ? options.tags.split(',').map((s) => s.trim())
     : [];
 
-  const projectNames = names(options.name);
   return {
     ...options,
-    name: projectNames.fileName,
-    moduleName: projectNames.propertyName.toLowerCase(),
-    npmScope: getProjectScope(tree),
+    name: names(options.name).fileName,
+    moduleName: names(projectName).propertyName.toLowerCase(),
     projectNameAndRootFormat,
     projectName,
     projectRoot,


### PR DESCRIPTION
This PR modifies the project names used in the generators to improve the Go module and package names in the generated files.

Resolves #118 