### PR TITLE
Add a generate executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ nx g @nx-go/nx-go:convert-to-one-mod
 ### Executors
 
 - `build`: [Build a Go project](./docs/executors/build.md)
+- `generate`: [Generate code using Go](./docs/executors/generate.md)
 - `lint`: [Format and lint a Go project](./docs/executors/lint.md)
 - `serve`: [Run a Go application](./docs/executors/serve.md)
 - `test`: [Run tests of a Go project](./docs/executors/test.md)

--- a/docs/executors/generate.md
+++ b/docs/executors/generate.md
@@ -1,0 +1,9 @@
+# @nx-go/nx-go:generate
+
+Runs `go generate` to execute an external tool which will generate code.
+
+## Options
+
+### args
+
+- (array): Extra args when running the command

--- a/packages/nx-go-e2e/shared/update-nx-config.ts
+++ b/packages/nx-go-e2e/shared/update-nx-config.ts
@@ -1,0 +1,13 @@
+import { updateFile } from '@nx/plugin/testing';
+import { join } from 'path';
+
+export const addNxTarget = (
+  directory: string,
+  target: string,
+  targetConfig: object
+): void =>
+  updateFile(join(directory, 'project.json'), (content) => {
+    const json = JSON.parse(content);
+    json['targets'][target] = targetConfig;
+    return JSON.stringify(json);
+  });

--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -10,6 +10,7 @@ import { execSync } from 'child_process';
 import { rmSync } from 'fs';
 import { join } from 'path';
 import createTestProject from '../shared/create-test-project';
+import { addNxTarget } from '../shared/update-nx-config';
 
 describe('nx-go', () => {
   const appName = uniq('app');
@@ -92,6 +93,17 @@ describe('nx-go', () => {
     it('should execute go mod tidy', async () => {
       const result = await runNxCommandAsync(`tidy ${appName}`);
       expect(result.stdout).toContain(`Executing command: go mod tidy`);
+    });
+  });
+
+  describe('Generate', () => {
+    beforeAll(() =>
+      addNxTarget(appName, 'generate', { executor: '@nx-go/nx-go:generate' })
+    );
+
+    it('should execute go generate', async () => {
+      const result = await runNxCommandAsync(`run ${appName}:generate`);
+      expect(result.stdout).toContain(`Executing command: go generate`);
     });
   });
 

--- a/packages/nx-go/executors.json
+++ b/packages/nx-go/executors.json
@@ -5,6 +5,11 @@
       "schema": "./src/executors/build/schema.json",
       "description": "Build the executable of a Go program"
     },
+    "generate": {
+      "implementation": "./src/executors/generate/executor",
+      "schema": "./src/executors/generate/schema.json",
+      "description": "Run a tool using Go generate"
+    },
     "lint": {
       "implementation": "./src/executors/lint/executor",
       "schema": "./src/executors/lint/schema.json",

--- a/packages/nx-go/migrations.json
+++ b/packages/nx-go/migrations.json
@@ -19,6 +19,11 @@
       "version": "3.1.0",
       "description": "Add tidy target to libraries and applications",
       "implementation": "./src/migrations/update-3.1.0/add-tidy-target-to-libraries-and-applications"
+    },
+    "replace-run-commands-with-generate-executor": {
+      "version": "3.2.0",
+      "description": "Use generate executor in projects using a \"run-commands\" target for generating code.",
+      "implementation": "./src/migrations/update-3.2.0/replace-run-commands-with-generate-executor"
     }
   }
 }

--- a/packages/nx-go/src/executors/generate/executor.spec.ts
+++ b/packages/nx-go/src/executors/generate/executor.spec.ts
@@ -1,0 +1,36 @@
+import { ExecutorContext } from '@nx/devkit';
+import * as sharedFunctions from '../../utils';
+import executor from './executor';
+import { GenerateExecutorSchema } from './schema';
+
+jest.mock('../../utils', () => ({
+  executeCommand: jest.fn().mockResolvedValue({ success: true }),
+  extractProjectRoot: jest.fn(() => 'apps/project'),
+}));
+
+const options: GenerateExecutorSchema = {};
+
+const context: ExecutorContext = {
+  cwd: 'current-dir',
+  root: '',
+  isVerbose: false,
+};
+
+describe('Generate Executor', () => {
+  it('should execute generate command with default options', async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBeTruthy();
+    expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(['generate'], {
+      cwd: 'apps/project',
+    });
+  });
+
+  it('should execute generate command with custom options', async () => {
+    const output = await executor({ ...options, args: ['-v'] }, context);
+    expect(output.success).toBeTruthy();
+    expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
+      ['generate', '-v'],
+      { cwd: 'apps/project' }
+    );
+  });
+});

--- a/packages/nx-go/src/executors/generate/executor.ts
+++ b/packages/nx-go/src/executors/generate/executor.ts
@@ -1,0 +1,18 @@
+import type { ExecutorContext } from '@nx/devkit';
+import { executeCommand, extractProjectRoot } from '../../utils';
+import type { GenerateExecutorSchema } from './schema';
+
+/**
+ * This executor runs a tool using `go generate` command.
+ *
+ * @param schema options passed to the executor
+ * @param context context passed to the executor
+ */
+export default async function runExecutor(
+  schema: GenerateExecutorSchema,
+  context: ExecutorContext
+) {
+  return executeCommand(['generate', ...(schema.args ?? [])], {
+    cwd: extractProjectRoot(context),
+  });
+}

--- a/packages/nx-go/src/executors/generate/schema.d.ts
+++ b/packages/nx-go/src/executors/generate/schema.d.ts
@@ -1,0 +1,3 @@
+export interface GenerateExecutorSchema {
+  args?: string[];
+}

--- a/packages/nx-go/src/executors/generate/schema.json
+++ b/packages/nx-go/src/executors/generate/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Generate executor",
+  "description": "Runs the `go generate` command",
+  "type": "object",
+  "properties": {
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Extra args when running Go generate command"
+    }
+  },
+  "required": []
+}

--- a/packages/nx-go/src/migrations/update-3.2.0/replace-run-commands-with-generate-executor.spec.ts
+++ b/packages/nx-go/src/migrations/update-3.2.0/replace-run-commands-with-generate-executor.spec.ts
@@ -1,0 +1,62 @@
+import * as devkit from '@nx/devkit';
+import { ProjectConfiguration, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { TargetConfiguration } from 'nx/src/config/workspace-json-project-json';
+import update from './replace-run-commands-with-generate-executor';
+
+jest.mock('@nx/devkit');
+
+describe('replace-run-commands-with-generate-executor migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => (tree = createTreeWithEmptyWorkspace()));
+  afterEach(() => jest.clearAllMocks());
+
+  const createProjectMapWithTarget = (targets: {
+    [targetName: string]: Partial<TargetConfiguration>;
+  }) =>
+    new Map([['api', { root: 'apps/api', targets } as ProjectConfiguration]]);
+
+  it.each`
+    endCommand    | cwd                | expectedArgs       | description
+    ${''}         | ${'{projectRoot}'} | ${null}            | ${'command in the project root'}
+    ${''}         | ${'apps/api'}      | ${null}            | ${'command in the project folder'}
+    ${' ./...'}    | ${'{projectRoot}'} | ${['./...']}       | ${'one argument'}
+    ${' ./... -p'} | ${'{projectRoot}'} | ${['./...', '-p']} | ${'two arguments'}
+  `(
+    'should update targets with $description',
+    async ({ endCommand, cwd, expectedArgs }) => {
+      const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+      jest.spyOn(devkit, 'getProjects').mockReturnValue(
+        createProjectMapWithTarget({
+          generate: {
+            executor: `nx:run-commands`,
+            options: { command: `go generate${endCommand}`, cwd },
+          },
+        })
+      );
+      await update(tree);
+      expect(updateConfig).toHaveBeenCalledWith(tree, 'api', expect.anything());
+      expect(updateConfig.mock.calls[0][2].targets.generate).toEqual({
+        executor: '@nx-go/nx-go:generate',
+        options: expectedArgs != null ? { args: expectedArgs } : undefined,
+      });
+    }
+  );
+
+  it.each`
+    options                                                                | description
+    ${{ command: 'npm install' }}                                          | ${'another command'}
+    ${{ command: 'go generate', cwd: 'other-folder/' }}                    | ${'a command in another folder'}
+    ${{ command: 'go generate', cwd: '{projectRoot}', envFile: ['.env'] }} | ${'a complex use case'}
+  `('should not update targets with $description', async ({ options }) => {
+    const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+    jest.spyOn(devkit, 'getProjects').mockReturnValue(
+      createProjectMapWithTarget({
+        generate: { executor: `nx:run-commands`, options },
+      })
+    );
+    await update(tree);
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx-go/src/migrations/update-3.2.0/replace-run-commands-with-generate-executor.ts
+++ b/packages/nx-go/src/migrations/update-3.2.0/replace-run-commands-with-generate-executor.ts
@@ -25,10 +25,8 @@ export default async function update(tree: Tree) {
     const goGenerateTarget = getGoGenerateTarget(projectConfig);
 
     if (goGenerateTarget != null) {
-      const args: string =
-        goGenerateTarget[1].options?.command
-          ?.replace(generateCommand, '')
-          ?.trim() ?? '';
+      const command = goGenerateTarget[1].options?.command;
+      const args: string = command?.replace(generateCommand, '').trim() ?? '';
 
       projectConfig.targets[goGenerateTarget[0]] = {
         executor: '@nx-go/nx-go:generate',

--- a/packages/nx-go/src/migrations/update-3.2.0/replace-run-commands-with-generate-executor.ts
+++ b/packages/nx-go/src/migrations/update-3.2.0/replace-run-commands-with-generate-executor.ts
@@ -1,0 +1,57 @@
+import {
+  formatFiles,
+  getProjects,
+  type ProjectConfiguration,
+  type TargetConfiguration,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+
+const generateCommand = 'go generate';
+
+/**
+ * Use nx-go generate executor in projects using a
+ * "run-commands" target for generating code.
+ *
+ * @note This migration only supports the most basic use case.
+ * @param tree the project tree
+ */
+export default async function update(tree: Tree) {
+  const projects = getProjects(tree);
+
+  for (const [projectName, projectConfig] of projects) {
+    if (!projectConfig.targets) continue;
+
+    const goGenerateTarget = getGoGenerateTarget(projectConfig);
+
+    if (goGenerateTarget != null) {
+      const args: string =
+        goGenerateTarget[1].options?.command
+          ?.replace(generateCommand, '')
+          ?.trim() ?? '';
+
+      projectConfig.targets[goGenerateTarget[0]] = {
+        executor: '@nx-go/nx-go:generate',
+        options: args.length > 0 ? { args: args.split(' ') } : undefined,
+      };
+
+      updateProjectConfiguration(tree, projectName, projectConfig);
+    }
+  }
+
+  await formatFiles(tree);
+}
+
+const getGoGenerateTarget = (
+  projectConfig: ProjectConfiguration
+): [string, TargetConfiguration] | null =>
+  // do not detect shorthand target because the command needs to be executed in the project directory
+  Object.entries(projectConfig.targets).find(
+    ([, target]) =>
+      target.executor === 'nx:run-commands' &&
+      target.options != null &&
+      Object.keys(target.options).length === 2 &&
+      target.options.command?.startsWith(generateCommand) &&
+      (target.options.cwd === projectConfig.root ||
+        target.options.cwd === '{projectRoot}')
+  );


### PR DESCRIPTION
I propose to add a "generate" executor which will execute the `go generate` command inside a Nx project.
Not all developers use this Golang feature, so I haven't added it to **nx-go** generators.

I'll probably add an automatic migration for users who use it via a `run-command` today!

Resolve #53 