### PR TITLE
Add skip cache property to test executor

### DIFF
--- a/docs/executors/test.md
+++ b/docs/executors/test.md
@@ -23,3 +23,7 @@ Uses `go test` command to run tests of a Go project.
 ### verbose
 
 - (boolean): Enable verbose test output
+
+### skipCache
+
+- (boolean): Skips go test caching and force retest the go project

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -33,6 +33,7 @@ describe('Test Executor', () => {
     ${{ coverProfile: 'coverage.out' }} | ${'-coverprofile=coverage.out'}
     ${{ race: true }}                   | ${'-race'}
     ${{ run: 'TestProjection' }}        | ${'-run=TestProjection'}
+    ${{ skipCache: true }}              | ${'-count=1'}
   `('should add flag $flag if enabled', async ({ config, flag }) => {
     const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
     const output = await executor({ ...options, ...config }, context);

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -20,6 +20,7 @@ export default async function runExecutor(
       ...buildStringFlagIfValid(`-coverprofile`, options.coverProfile),
       ...buildFlagIfEnabled('-race', options.race),
       ...buildStringFlagIfValid(`-run`, options.run),
+      ...buildFlagIfEnabled('-count=1', options.skipCache),
       './...',
     ],
     { cwd: extractProjectRoot(context) }

--- a/packages/nx-go/src/executors/test/schema.d.ts
+++ b/packages/nx-go/src/executors/test/schema.d.ts
@@ -4,4 +4,5 @@ export interface TestExecutorSchema {
   race?: boolean;
   run?: string;
   verbose?: boolean;
+  skipCache?: boolean;
 }

--- a/packages/nx-go/src/executors/test/schema.json
+++ b/packages/nx-go/src/executors/test/schema.json
@@ -28,6 +28,11 @@
       "description": "Whether to enable verbose test output",
       "type": "boolean",
       "default": false
+    },
+    "skipCache": {
+      "description": "Whether to skip the cache when running go tests",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": []


### PR DESCRIPTION
This PR adds the "skipCache" property to the test executor, in order force retest the golang tests. The test executor will run the go command with flag `count=1` if skipCache is true

Closes #124 