### PR TITLE
feat: add buildMode property to build executor

### DIFF
--- a/docs/executors/build.md
+++ b/docs/executors/build.md
@@ -12,6 +12,10 @@ Builds a project with `go build` cli command.
 
 - (string): The output path of the resulting executable
 
+### buildMode
+
+- (string): Build mode to use
+
 ### env
 
 - (object): Environment variables to set when running the executor

--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -1,5 +1,9 @@
 import { ExecutorContext } from '@nx/devkit';
-import { executeCommand, extractProjectRoot } from '../../utils';
+import {
+  buildStringFlagIfValid,
+  executeCommand,
+  extractProjectRoot,
+} from '../../utils';
 import { BuildExecutorSchema } from './schema';
 
 /**
@@ -26,6 +30,7 @@ const buildParams = (
     'build',
     '-o',
     buildOutputPath(extractProjectRoot(context), options.outputPath),
+    ...buildStringFlagIfValid('-buildmode', options.buildMode),
     ...(options.flags ?? []),
     options.main,
   ];

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -1,6 +1,7 @@
 export interface BuildExecutorSchema {
   main: string;
   outputPath?: string;
+  buildMode?: string;
   env?: { [key: string]: string };
   flags?: string[];
 }

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -17,6 +17,10 @@
       "type": "string",
       "description": "The output path of the resulting executable"
     },
+    "buildMode": {
+      "type": "string",
+      "description": "The build mode to use"
+    },
     "env": {
       "type": "object",
       "additionalProperties": {

--- a/packages/nx-go/src/executors/test/executor.spec.ts
+++ b/packages/nx-go/src/executors/test/executor.spec.ts
@@ -3,10 +3,16 @@ import * as commonFunctions from '../../utils';
 import executor from './executor';
 import type { TestExecutorSchema } from './schema';
 
-jest.mock('../../utils', () => ({
-  executeCommand: jest.fn().mockResolvedValue({ success: true }),
-  extractProjectRoot: jest.fn(() => 'apps/project'),
-}));
+jest.mock('../../utils', () => {
+  const { buildFlagIfEnabled, buildStringFlagIfValid } =
+    jest.requireActual('../../utils');
+  return {
+    buildFlagIfEnabled,
+    buildStringFlagIfValid,
+    executeCommand: jest.fn().mockResolvedValue({ success: true }),
+    extractProjectRoot: jest.fn(() => 'apps/project'),
+  };
+});
 
 const options: TestExecutorSchema = {};
 
@@ -33,7 +39,7 @@ describe('Test Executor', () => {
     ${{ coverProfile: 'coverage.out' }} | ${'-coverprofile=coverage.out'}
     ${{ race: true }}                   | ${'-race'}
     ${{ run: 'TestProjection' }}        | ${'-run=TestProjection'}
-    ${{ count: 1 }}                   | ${'-count=1'}
+    ${{ count: 1 }}                     | ${'-count=1'}
   `('should add flag $flag if enabled', async ({ config, flag }) => {
     const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
     const output = await executor({ ...options, ...config }, context);

--- a/packages/nx-go/src/executors/test/executor.ts
+++ b/packages/nx-go/src/executors/test/executor.ts
@@ -1,5 +1,10 @@
 import type { ExecutorContext } from '@nx/devkit';
-import { executeCommand, extractProjectRoot } from '../../utils';
+import {
+  buildFlagIfEnabled,
+  buildStringFlagIfValid,
+  executeCommand,
+  extractProjectRoot,
+} from '../../utils';
 import type { TestExecutorSchema } from './schema';
 
 /**
@@ -12,7 +17,6 @@ export default async function runExecutor(
   options: TestExecutorSchema,
   context: ExecutorContext
 ) {
-
   return executeCommand(
     [
       'test',
@@ -21,17 +25,12 @@ export default async function runExecutor(
       ...buildStringFlagIfValid(`-coverprofile`, options.coverProfile),
       ...buildFlagIfEnabled('-race', options.race),
       ...buildStringFlagIfValid(`-run`, options.run),
-      ...buildStringFlagIfValid('-count', options.count > 0 ? options.count.toString() : undefined),
+      ...buildStringFlagIfValid(
+        '-count',
+        options.count > 0 ? options.count.toString() : undefined
+      ),
       './...',
     ],
     { cwd: extractProjectRoot(context) }
   );
 }
-
-const buildFlagIfEnabled = (flag: string, enabled: boolean): string[] => {
-  return enabled ? [flag] : [];
-};
-
-const buildStringFlagIfValid = (flag: string, value?: string): string[] => {
-  return value ? [`${flag}=${value}`] : [];
-};

--- a/packages/nx-go/src/utils/execute-command.spec.ts
+++ b/packages/nx-go/src/utils/execute-command.spec.ts
@@ -1,6 +1,11 @@
 import { logger } from '@nx/devkit';
 import * as child_process from 'child_process';
-import { executeCommand, extractProjectRoot } from './execute-command';
+import {
+  buildFlagIfEnabled,
+  buildStringFlagIfValid,
+  executeCommand,
+  extractProjectRoot,
+} from './execute-command';
 
 jest.mock('@nx/devkit', () => ({
   logger: { info: jest.fn(), error: jest.fn() },
@@ -65,6 +70,26 @@ describe('Execute command', () => {
       expect(result.success).toBeFalsy();
       expect(logger.error).toHaveBeenCalledWith(spawnError);
       expect(logger.info).toHaveBeenCalledWith('Executing command: go version');
+    });
+  });
+
+  describe('Method: buildFlagIfEnabled', () => {
+    it('should add a flag because enabled', () => {
+      expect(buildFlagIfEnabled('--flag1', true)).toEqual(['--flag1']);
+    });
+
+    it('should not add a flag because not enabled', () => {
+      expect(buildFlagIfEnabled('--flag1', false)).toEqual([]);
+    });
+  });
+
+  describe('Method: buildStringFlagIfValid', () => {
+    it('should add a flag because valid', () => {
+      expect(buildStringFlagIfValid('--flag1', 'v1')).toEqual(['--flag1=v1']);
+    });
+
+    it('should not add a flag because not valid', () => {
+      expect(buildStringFlagIfValid('--flag1')).toEqual([]);
     });
   });
 });

--- a/packages/nx-go/src/utils/execute-command.ts
+++ b/packages/nx-go/src/utils/execute-command.ts
@@ -41,3 +41,23 @@ export const executeCommand = async (
     return { success: false };
   }
 };
+
+/**
+ * Add a flag to an array of parameter if it is enabled.
+ *
+ * @param flag the flag to add
+ * @param enabled true if flag should be added
+ */
+export const buildFlagIfEnabled = (flag: string, enabled: boolean): string[] =>
+  enabled ? [flag] : [];
+
+/**
+ * Add a string flag to an array of parameter if it is valid.
+ *
+ * @param flag the flag to add
+ * @param value the value of the flag
+ */
+export const buildStringFlagIfValid = (
+  flag: string,
+  value?: string
+): string[] => (value ? [`${flag}=${value}`] : []);


### PR DESCRIPTION
This PR adds the "buildMode" property to the build executor, in order to indicate which kind of object file is to be built (as described [here](https://pkg.go.dev/cmd/go#hdr-Build_modes) in the Go documentation).

Closes #43