### PR TITLE
chore: stick pnpm version to v8

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,25 +18,21 @@ runs:
     - name: Use Go ${{ inputs.go_version }}
       uses: actions/setup-go@v5
       with:
+        cache: false # we do not install Go modules, so we do not need to cache them
         go-version: ${{ inputs.go_version }}
+
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4.0.0
+      with:
+        run_install: false
 
     - name: Use Node.js ${{ inputs.node_version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node_version }}
         registry-url: 'https://registry.npmjs.org'
+        cache: 'pnpm'
 
-    - name: 💼 Cache pnpm modules
-      uses: actions/cache@v4
-      with:
-        path: ~/.pnpm-store
-        key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-
-
-    - name: 🔧 Install dependencies
-      uses: pnpm/action-setup@v4.0.0
-      with:
-        version: 8.15.x
-        run_install: |
-          - args: [--frozen-lockfile, --strict-peer-dependencies]
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile --strict-peer-dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ testem.log
 Thumbs.db
 
 .nx/cache
+.nx/workspace-data

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@
 /dist
 /coverage
 /.nx/cache
+/.nx/workspace-data
 pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
   },
   "nx": {
     "includedScripts": []
-  }
+  },
+  "packageManager": "pnpm@8.15.9+sha256.daa27a0b541bc635323ff96c2ded995467ff9fe6d69ff67021558aa9ad9dcc36"
 }


### PR DESCRIPTION
I've found out that **Nx 17.x** is not compatible with **pnpm v9**.
But as the version is not frozen in the package.json file, it installed version 9 on my computer and nothing worked. To avoid any error until #137 is merged, I have explicitly set the pnpm version in the `package.json` file.