### PR TITLE
Add support of Nx 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go_version: [ 1.22.3 ]
-        node_version: [ 20.x ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go_version: [1.23.2]
+        node_version: [22.x]
     steps:
       - name: 📥 Checkout Repo
         uses: actions/checkout@v4
@@ -41,8 +41,8 @@ jobs:
       - name: ⚙ Setup
         uses: ./.github/actions/setup
         with:
-          go_version: 1.22.3
-          node_version: 20.x
+          go_version: 1.23.2
+          node_version: 22.x
 
       - name: 💭 Validate current commit (last commit) with commitlint
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
       - name: ⚙ Setup
         uses: ./.github/actions/setup
         with:
-          go_version: 1.22.3
-          node_version: 20.x
+          go_version: 1.23.2
+          node_version: 22.x
 
       - name: Configure Git
         run: |

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Want to try out these capabilities quickly? Visit our [playground](https://githu
 ## 🧩 Compatibility
 
 | nx-go version | Nx version   |
-|---------------|--------------|
-| 3.x           | 17.x to 19.x |
+| ------------- | ------------ |
+| 3.x           | 17.x to 20.x |
 | 2.x           | 13.x to 16.x |
 | 1.x           | < 13.x       |
 

--- a/packages/nx-go/package.json
+++ b/packages/nx-go/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/nx-go/nx-go/issues"
   },
   "dependencies": {
-    "@nx/devkit": "^17.0.0 || ^18.0.0 || ^19.0.0",
+    "@nx/devkit": ">= 17 < 21",
     "tslib": "^2.3.0"
   },
   "type": "commonjs",


### PR DESCRIPTION
This PR includes updates to various configuration files to support newer versions of Go and Node.js, as well as updates to compatibility information for `nx-go` with Nx.

### Configuration updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL15-R16): Updated Go version to `1.23.2` and Node.js version to `22.x` in the matrix strategy and setup steps. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL15-R16) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL44-R45)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R21): Updated Go version to `1.23.2` and Node.js version to `22.x` in the setup steps.

### Compatibility updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R79): Updated compatibility table to include Nx version `20.x` for `nx-go` version `3.x`.
* [`packages/nx-go/package.json`](diffhunk://#diff-6b3619922f31aa5358c0130234b5640c2412312b966cbb2535e70396ad243109L21-R21): Updated `@nx/devkit` dependency to include version `20.0.0`.