### PR TITLE
Add an option to use the plugin without Go installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ nx g @nx-go/nx-go:convert-to-one-mod
 
 Want to try out these capabilities quickly? Visit our [playground](https://github.com/nx-go/nx-go-playground)!
 
+Need more customization? A [plugin configuration](./docs/options.md) is also available.
+
 ## 🧩 Compatibility
 
 | nx-go version | Nx version   |

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,27 @@
+# @nx-go/nx-go options
+
+The plugin allows to configure its behavior with global options.
+
+## Usage
+
+Import the plugin with an object instead of a simple string in your `nx.json` file.
+
+Here is an example:
+
+```json
+{
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "plugins": [
+    {
+      "plugin": "@nx-go/nx-go",
+      "options": { "skipGoDependencyCheck": true }
+    }
+  ]
+}
+```
+
+## Options
+
+### skipGoDependencyCheck
+
+- (boolean): if true, the plugin will not require to have Go installed to compute a Nx workspace graph. Be aware that if Go is not installed, the plugin will not be able to detect dependencies between Go projects and this is source of misunderstanding.

--- a/packages/nx-go/src/type.d.ts
+++ b/packages/nx-go/src/type.d.ts
@@ -1,0 +1,10 @@
+export interface NxGoPluginOptions {
+  /**
+   * If true, the plugin will not require
+   * to have Go installed to compute a Nx workspace graph.
+   *
+   * Be aware that if Go is not installed, the plugin will not be able
+   * to detect dependencies between Go projects and this is source of misunderstanding.
+   */
+  skipGoDependencyCheck?: boolean;
+}

--- a/packages/nx-go/src/utils/go-bridge.spec.ts
+++ b/packages/nx-go/src/utils/go-bridge.spec.ts
@@ -7,6 +7,7 @@ import {
   addGoWorkDependency,
   createGoMod,
   createGoWork,
+  getGoModules,
   getGoShortVersion,
   getGoVersion,
   isGoWorkspace,
@@ -49,6 +50,32 @@ describe('Go bridge', () => {
       jest.spyOn(child_process, 'execSync').mockImplementationOnce(() => null);
       expect(() => getGoShortVersion()).toThrow(
         'Cannot retrieve current Go version'
+      );
+    });
+  });
+
+  describe('Method: getGoModules', () => {
+    it('should return output of go list -m -json command', () => {
+      const mockOutput = '{"Path":"example.com/module","Version":"v1.0.0"}';
+      jest.spyOn(child_process, 'execSync').mockReturnValueOnce(mockOutput);
+      const result = getGoModules('/path/to/project', false);
+      expect(result).toEqual(mockOutput);
+    });
+
+    it('should return empty string if command fails and failSilently is true', () => {
+      jest.spyOn(child_process, 'execSync').mockImplementationOnce(() => {
+        throw new Error('Command failed');
+      });
+      const result = getGoModules('/path/to/project', true);
+      expect(result).toEqual('');
+    });
+
+    it('should throw error if command fails and failSilently is false', () => {
+      jest.spyOn(child_process, 'execSync').mockImplementationOnce(() => {
+        throw new Error('Command failed');
+      });
+      expect(() => getGoModules('/path/to/project', false)).toThrow(
+        'Command failed'
       );
     });
   });

--- a/packages/nx-go/src/utils/go-bridge.ts
+++ b/packages/nx-go/src/utils/go-bridge.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nx/devkit';
+import { type Tree } from '@nx/devkit';
 import { execSync } from 'child_process';
 import { join } from 'path';
 import {
@@ -32,6 +32,32 @@ export const getGoVersion = (): string => {
 export const getGoShortVersion = (): string => {
   const [major, minor] = getGoVersion().split('.');
   return `${major}.${minor}`;
+};
+
+/**
+ * Executes the `go list -m -json` command in the
+ * specified directory and returns the output as a string.
+ *
+ * @param cwd the current working directory where the command should be executed.
+ * @param failSilently if true, the function will return an empty string instead of throwing an error when the command fails.
+ * @returns The output of the `go list -m -json` command as a string.
+ * @throws Will throw an error if the command fails and `failSilently` is false.
+ */
+export const getGoModules = (cwd: string, failSilently: boolean): string => {
+  try {
+    return execSync('go list -m -json', {
+      encoding: 'utf-8',
+      cwd,
+      stdio: ['ignore'],
+      windowsHide: true,
+    });
+  } catch (error) {
+    if (failSilently) {
+      return '';
+    } else {
+      throw error;
+    }
+  }
 };
 
 /**


### PR DESCRIPTION
This PR adds a global option to the plugin called `skipGoDependencyCheck` in order to use the plugin without Go installed on your machine. This is a solution to avoid all members collaborating on the same monorepo having to install the Golang stack, if they are only working on other projects in the workspace.

> [!WARNING]
> Please be aware that if Go is not installed, the plugin will not be able to detect dependencies between Go projects and this is source of misunderstanding. So use this option with the utmost caution.

↪️ What do you think of the name of the option `skipGoDependencyCheck`?

## How to use this feature?

In `nx.json` file, you can pass an object with options when adding `@nx-go/nx-go` plugin.

```json
{
  "$schema": "./node_modules/nx/schemas/nx-schema.json",
  "plugins": [
    {
      "plugin": "@nx-go/nx-go",
      "options": { "skipGoDependencyCheck": true }
    }
  ]
}

```

## Examples

### With Golang installed (regardless of the value of `skipGoDependencyCheck`):

![image](https://github.com/user-attachments/assets/bac0d29d-6ee1-49d2-9a7a-ca8c5317278a)

### Without Golang installed, with `skipGoDependencyCheck = false`:

![image](https://github.com/user-attachments/assets/e475d154-36bd-451f-93cc-e37336920fcd)

### Without Golang installed, with `skipGoDependencyCheck = true`: **(NEW)**

![image](https://github.com/user-attachments/assets/2527bacf-ee31-4b8a-84c8-1a6051060540)
