### PR TITLE
fix: update options normalization for Nx 20 compatibility

### DIFF
--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -75,6 +75,19 @@ describe('nx-go', () => {
     expect(projectType).toEqual('library');
   });
 
+  it('should create an application in a sub directory', async () => {
+    const name = uniq('app');
+    // directory is not derived since Nx 20
+    const directory = process.env.NX_VERSION.startsWith('20')
+      ? `apps/${name}`
+      : 'apps';
+    await runNxCommandAsync(
+      `generate @nx-go/nx-go:application ${name} --directory=${directory}`
+    );
+    expect(() => checkFilesExist(`apps/${name}/main.go`)).not.toThrow();
+    expect(() => checkFilesExist(`apps/${name}/go.mod`)).not.toThrow();
+  });
+
   it('should build the application', async () => {
     const result = await runNxCommandAsync(`build ${appName}`);
     const ext = process.platform === 'win32' ? '.exe' : '';

--- a/packages/nx-go/src/generators/application/generator.spec.ts
+++ b/packages/nx-go/src/generators/application/generator.spec.ts
@@ -2,6 +2,7 @@ const normalizeOptions = {
   name: 'my-api',
   moduleName: 'myapi',
   projectRoot: 'apps/my-api',
+  projectName: 'my-api',
   projectType: 'application',
   parsedTags: ['api', 'backend'],
 };
@@ -19,12 +20,15 @@ jest.mock('../../utils', () => ({
   addGoWorkDependency: jest.fn(),
   createGoMod: jest.fn(),
   isGoWorkspace: jest.fn().mockReturnValue(false),
-  normalizeOptions: jest.fn().mockReturnValue(normalizeOptions),
+  normalizeOptions: jest.fn().mockImplementation((_, { skipFormat }) => ({
+    ...normalizeOptions,
+    skipFormat,
+  })),
 }));
 
 describe('application generator', () => {
   let tree: Tree;
-  const options: ApplicationGeneratorSchema = { name: 'test' };
+  const options: ApplicationGeneratorSchema = { name: 'my-api' };
 
   beforeEach(() => (tree = createTreeWithEmptyWorkspace()));
   afterEach(() => jest.clearAllMocks());
@@ -33,9 +37,10 @@ describe('application generator', () => {
     await applicationGenerator(tree, options);
     expect(nxDevkit.addProjectConfiguration).toHaveBeenCalledWith(
       tree,
-      'test',
+      'my-api',
       {
         root: 'apps/my-api',
+        name: 'my-api',
         projectType: 'application',
         sourceRoot: 'apps/my-api',
         targets: defaultTargets,
@@ -70,9 +75,10 @@ describe('application generator', () => {
     await applicationGenerator(tree, options);
     expect(nxDevkit.updateProjectConfiguration).toHaveBeenCalledWith(
       tree,
-      'test',
+      'my-api',
       {
         root: 'apps/my-api',
+        name: 'my-api',
         projectType: 'application',
         sourceRoot: 'apps/my-api',
         targets: {

--- a/packages/nx-go/src/generators/application/generator.ts
+++ b/packages/nx-go/src/generators/application/generator.ts
@@ -49,13 +49,14 @@ export default async function applicationGenerator(
   );
   const projectConfiguration: ProjectConfiguration = {
     root: options.projectRoot,
+    name: options.projectName,
     projectType: options.projectType,
     sourceRoot: options.projectRoot,
     tags: options.parsedTags,
     targets: defaultTargets,
   };
 
-  addProjectConfiguration(tree, schema.name, projectConfiguration);
+  addProjectConfiguration(tree, options.name, projectConfiguration);
 
   generateFiles(tree, join(__dirname, 'files'), options.projectRoot, options);
 
@@ -65,10 +66,10 @@ export default async function applicationGenerator(
     projectConfiguration.targets.tidy = {
       executor: '@nx-go/nx-go:tidy',
     };
-    updateProjectConfiguration(tree, schema.name, projectConfiguration);
+    updateProjectConfiguration(tree, options.name, projectConfiguration);
   }
 
-  if (!schema.skipFormat) {
+  if (!options.skipFormat) {
     await formatFiles(tree);
   }
 }

--- a/packages/nx-go/src/generators/library/generator.spec.ts
+++ b/packages/nx-go/src/generators/library/generator.spec.ts
@@ -26,7 +26,10 @@ jest.mock('../../utils', () => ({
   addGoWorkDependency: jest.fn(),
   createGoMod: jest.fn(),
   isGoWorkspace: jest.fn().mockReturnValue(false),
-  normalizeOptions: jest.fn().mockReturnValue(normalizeOptions),
+  normalizeOptions: jest.fn().mockImplementation((_, { skipFormat }) => ({
+    ...normalizeOptions,
+    skipFormat,
+  })),
 }));
 
 describe('library generator', () => {
@@ -43,6 +46,7 @@ describe('library generator', () => {
       'data-access',
       {
         root: 'libs/data-access',
+        name: 'data-access',
         projectType: 'library',
         sourceRoot: 'libs/data-access',
         targets: defaultTargets,
@@ -94,6 +98,7 @@ describe('library generator', () => {
       'data-access',
       {
         root: 'libs/data-access',
+        name: 'data-access',
         projectType: 'library',
         sourceRoot: 'libs/data-access',
         targets: {

--- a/packages/nx-go/src/generators/library/generator.ts
+++ b/packages/nx-go/src/generators/library/generator.ts
@@ -38,6 +38,7 @@ export default async function libraryGenerator(
   );
   const projectConfiguration: ProjectConfiguration = {
     root: options.projectRoot,
+    name: options.projectName,
     projectType: options.projectType,
     sourceRoot: options.projectRoot,
     tags: options.parsedTags,
@@ -60,7 +61,7 @@ export default async function libraryGenerator(
     updateProjectConfiguration(tree, options.name, projectConfiguration);
   }
 
-  if (!schema.skipFormat) {
+  if (!options.skipFormat) {
     await formatFiles(tree);
   }
 }

--- a/packages/nx-go/src/utils/normalize-options.spec.ts
+++ b/packages/nx-go/src/utils/normalize-options.spec.ts
@@ -1,8 +1,10 @@
+import * as devkit from '@nx/devkit';
 import type { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { normalizeOptions } from './normalize-options';
 
 jest.mock('@nx/devkit', () => ({
+  NX_VERSION: '17.3.2',
   names: jest.fn().mockReturnValue({
     fileName: 'backend-filename',
     propertyName: 'backendFilename',
@@ -47,5 +49,16 @@ describe('normalizeOptions', () => {
       'init'
     );
     expect(output.parsedTags).toEqual(['api', 'web']);
+  });
+
+  it('should use name as directory if not passed when using Nx 20', async () => {
+    Object.defineProperty(devkit, 'NX_VERSION', { value: '20.2.1' });
+    const output = await normalizeOptions(
+      tree,
+      { name: 'backend' },
+      'application',
+      'init'
+    );
+    expect(output.directory).toBe('backend');
   });
 });

--- a/packages/nx-go/src/utils/normalize-options.ts
+++ b/packages/nx-go/src/utils/normalize-options.ts
@@ -1,11 +1,17 @@
-import { names, ProjectType, Tree } from '@nx/devkit';
+import { names, NX_VERSION, ProjectType, Tree } from '@nx/devkit';
 import {
   determineProjectNameAndRootOptions,
   ProjectNameAndRootFormat,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
 
 export interface GeneratorSchema {
+  /**
+   * TODO major: this property is optional in Nx 20
+   */
   name: string;
+  /**
+   * TODO major: this property is provided by default in Nx 20
+   */
   directory?: string;
   projectNameAndRootFormat?: ProjectNameAndRootFormat;
   tags?: string;
@@ -26,6 +32,8 @@ export const normalizeOptions = async (
   projectType: ProjectType,
   generator: string
 ): Promise<GeneratorNormalizedSchema> => {
+  ensureProjectDirectory(options);
+
   const { projectName, projectRoot, projectNameAndRootFormat } =
     await determineProjectNameAndRootOptions(tree, {
       name: options.name,
@@ -49,4 +57,11 @@ export const normalizeOptions = async (
     projectType,
     parsedTags,
   };
+};
+
+const ensureProjectDirectory = (options: GeneratorSchema) => {
+  // Nx 20 BREAKING CHANGE: `directory` is now mandatory and `name` is optional
+  if (NX_VERSION.startsWith('20') && options.directory === undefined) {
+    options.directory = options.name;
+  }
 };


### PR DESCRIPTION
This pull request adapts the normalization options code to a breaking change in Nx 20.

It's a quick fix to allow generators working on Nx 17-20, but we'll have to clean up and release a version compatible only with Nx 20 soon, to avoid tweaks like this one. In particular, we will need to change default argument from "name" to "directory" to reflect better how Nx 20 works.

> [!NOTE]
> In order to avoid forcing everyone to upgrade to Nx 20 in a hurry, I haven't yet planned to deprecate older versions. The choice will be made in another ticket.

Fixes #145