### PR TITLE
feat: add flags property to serve executor

### DIFF
--- a/docs/executors/serve.md
+++ b/docs/executors/serve.md
@@ -19,3 +19,7 @@ Uses `go run` command to run a Go application.
 ### args
 
 - (array): Extra args when starting the app
+
+### flags
+
+- (array): Flags to pass to the go compiler

--- a/packages/nx-go/src/executors/serve/executor.spec.ts
+++ b/packages/nx-go/src/executors/serve/executor.spec.ts
@@ -51,6 +51,16 @@ describe('Serve Executor', () => {
     );
   });
 
+  it('should run Go program with custom flags', async () => {
+    const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
+    const output = await executor({ ...options, flags: ['-v', '-x'] }, context);
+    expect(output.success).toBeTruthy();
+    expect(spyExecute).toHaveBeenCalledWith(
+      ['run', '-v', '-x', 'hello_world.go'],
+      { cwd: 'apps/project' }
+    );
+  });
+
   it('should remove directory from main file path', async () => {
     const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
     const output = await executor(

--- a/packages/nx-go/src/executors/serve/executor.ts
+++ b/packages/nx-go/src/executors/serve/executor.ts
@@ -14,8 +14,8 @@ export default async function runExecutor(
 ) {
   const directory = options.cwd ?? extractProjectRoot(context);
   const mainFile = options.main.replace(`${directory}/`, '');
-  return executeCommand(['run', mainFile, ...(options.args ?? [])], {
-    executable: options.cmd,
-    cwd: directory,
-  });
+  return executeCommand(
+    ['run', ...(options.flags ?? []), mainFile, ...(options.args ?? [])],
+    { executable: options.cmd, cwd: directory }
+  );
 }

--- a/packages/nx-go/src/executors/serve/schema.d.ts
+++ b/packages/nx-go/src/executors/serve/schema.d.ts
@@ -3,4 +3,5 @@ export interface ServeExecutorSchema {
   cmd?: string;
   cwd?: string;
   args?: string[];
+  flags?: string[];
 }

--- a/packages/nx-go/src/executors/serve/schema.json
+++ b/packages/nx-go/src/executors/serve/schema.json
@@ -29,6 +29,13 @@
       },
       "description": "Extra args when starting the app",
       "alias": "arguments"
+    },
+    "flags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Flags to pass to the go compiler"
     }
   },
   "required": ["main"]


### PR DESCRIPTION
This pull request introduces the ability to pass custom flags to the Go compiler when running a Go application. The changes span documentation updates, schema modifications, and updates to the executor logic and tests.

Closes #77 