### PR TITLE
feat: add a download executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ nx g @nx-go/nx-go:convert-to-one-mod
 - `serve`: [Run a Go application](./docs/executors/serve.md)
 - `test`: [Run tests of a Go project](./docs/executors/test.md)
 - `tidy`: [Ensures go.mod file matches a project source code](./docs/executors/tidy.md)
+- `download`: [Downloads Go modules to local cache](./docs/executors/download.md)
 
 > [!TIP]
 > You can use `nx list @nx-go/nx-go` to see list capabilities.

--- a/docs/executors/download.md
+++ b/docs/executors/download.md
@@ -1,0 +1,9 @@
+# @nx-go/nx-go:download
+
+Runs `go mod download` to download Go modules to local cache.
+
+## Options
+
+### args
+
+- (array): Extra args when running the command

--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -117,6 +117,13 @@ describe('nx-go', () => {
     });
   });
 
+  describe('Download', () => {
+    it('should execute go mod download', async () => {
+      const result = await runNxCommandAsync(`download ${appName}`);
+      expect(result.stdout).toContain(`Executing command: go mod download`);
+    });
+  });
+
   describe('Generate', () => {
     beforeAll(() =>
       addNxTarget(appName, 'generate', { executor: '@nx-go/nx-go:generate' })

--- a/packages/nx-go/executors.json
+++ b/packages/nx-go/executors.json
@@ -20,6 +20,11 @@
       "schema": "./src/executors/tidy/schema.json",
       "description": "Tidy the mod file of the application or library"
     },
+    "download": {
+      "implementation": "./src/executors/download/executor",
+      "schema": "./src/executors/download/schema.json",
+      "description": "Download Go modules to local cache"
+    },
     "serve": {
       "implementation": "./src/executors/serve/executor",
       "schema": "./src/executors/serve/schema.json",

--- a/packages/nx-go/migrations.json
+++ b/packages/nx-go/migrations.json
@@ -24,6 +24,11 @@
       "version": "3.2.0",
       "description": "Use generate executor in projects using a \"run-commands\" target for generating code.",
       "implementation": "./src/migrations/update-3.2.0/replace-run-commands-with-generate-executor"
+    },
+    "add-download-targets": {
+      "version": "3.4.0",
+      "description": "Add download target to libraries and applications",
+      "implementation": "./src/migrations/update-3.4.0/add-download-target-to-libraries-and-applications"
     }
   }
 }

--- a/packages/nx-go/src/executors/download/executor.spec.ts
+++ b/packages/nx-go/src/executors/download/executor.spec.ts
@@ -1,0 +1,37 @@
+import { ExecutorContext } from '@nx/devkit';
+import * as sharedFunctions from '../../utils';
+import executor from './executor';
+import { DownloadExecutorSchema } from './schema';
+
+jest.mock('../../utils', () => ({
+  executeCommand: jest.fn().mockResolvedValue({ success: true }),
+  extractProjectRoot: jest.fn(() => 'apps/project'),
+}));
+
+const options: DownloadExecutorSchema = {};
+
+const context: ExecutorContext = {
+  cwd: 'current-dir',
+  root: '',
+  isVerbose: false,
+};
+
+describe('Download Executor', () => {
+  it('should execute download command with default options', async () => {
+    const output = await executor(options, context);
+    expect(output.success).toBeTruthy();
+    expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
+      ['mod', 'download'],
+      { cwd: 'apps/project' }
+    );
+  });
+
+  it('should execute download command with custom options', async () => {
+    const output = await executor({ ...options, args: ['--json'] }, context);
+    expect(output.success).toBeTruthy();
+    expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
+      ['mod', 'download', '--json'],
+      { cwd: 'apps/project' }
+    );
+  });
+});

--- a/packages/nx-go/src/executors/download/executor.ts
+++ b/packages/nx-go/src/executors/download/executor.ts
@@ -1,0 +1,18 @@
+import { ExecutorContext } from '@nx/devkit';
+import { executeCommand, extractProjectRoot } from '../../utils';
+import { DownloadExecutorSchema } from './schema';
+
+/**
+ * This executor runs go mod download on the specified module.
+ *
+ * @param schema options passed to the executor
+ * @param context context passed to the executor
+ */
+export default async function runExecutor(
+  schema: DownloadExecutorSchema,
+  context: ExecutorContext
+) {
+  return executeCommand(['mod', 'download', ...(schema.args ?? [])], {
+    cwd: extractProjectRoot(context),
+  });
+}

--- a/packages/nx-go/src/executors/download/schema.d.ts
+++ b/packages/nx-go/src/executors/download/schema.d.ts
@@ -1,0 +1,3 @@
+export interface DownloadExecutorSchema {
+  args?: string[];
+}

--- a/packages/nx-go/src/executors/download/schema.json
+++ b/packages/nx-go/src/executors/download/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Download executor",
+  "description": "Runs the `go mod download` command",
+  "type": "object",
+  "properties": {
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Extra args when mod download the app or library"
+    }
+  },
+  "required": []
+}

--- a/packages/nx-go/src/generators/application/generator.spec.ts
+++ b/packages/nx-go/src/generators/application/generator.spec.ts
@@ -92,6 +92,28 @@ describe('application generator', () => {
     );
   });
 
+  it('should add download executor for project if in a Go workspace', async () => {
+    jest.spyOn(shared, 'isGoWorkspace').mockReturnValueOnce(true);
+    await applicationGenerator(tree, options);
+    expect(nxDevkit.updateProjectConfiguration).toHaveBeenCalledWith(
+      tree,
+      'my-api',
+      {
+        root: 'apps/my-api',
+        name: 'my-api',
+        projectType: 'application',
+        sourceRoot: 'apps/my-api',
+        targets: {
+          ...defaultTargets,
+          download: {
+            executor: '@nx-go/nx-go:download',
+          },
+        },
+        tags: ['api', 'backend'],
+      }
+    );
+  });
+
   it('should not create Go mod for project if not in a Go workspace', async () => {
     await applicationGenerator(tree, options);
     expect(shared.createGoMod).not.toHaveBeenCalled();

--- a/packages/nx-go/src/generators/application/generator.ts
+++ b/packages/nx-go/src/generators/application/generator.ts
@@ -66,6 +66,9 @@ export default async function applicationGenerator(
     projectConfiguration.targets.tidy = {
       executor: '@nx-go/nx-go:tidy',
     };
+    projectConfiguration.targets.download = {
+      executor: '@nx-go/nx-go:download',
+    };
     updateProjectConfiguration(tree, options.name, projectConfiguration);
   }
 

--- a/packages/nx-go/src/generators/library/generator.spec.ts
+++ b/packages/nx-go/src/generators/library/generator.spec.ts
@@ -112,6 +112,28 @@ describe('library generator', () => {
     );
   });
 
+  it('should add download executor for project if in a Go workspace', async () => {
+    jest.spyOn(shared, 'isGoWorkspace').mockReturnValueOnce(true);
+    await libraryGenerator(tree, options);
+    expect(nxDevkit.updateProjectConfiguration).toHaveBeenCalledWith(
+      tree,
+      'data-access',
+      {
+        root: 'libs/data-access',
+        name: 'data-access',
+        projectType: 'library',
+        sourceRoot: 'libs/data-access',
+        targets: {
+          ...defaultTargets,
+          download: {
+            executor: '@nx-go/nx-go:download',
+          },
+        },
+        tags: ['data', 'data-access'],
+      }
+    );
+  });
+
   it('should not add Go work dependency if not in a Go workspace', async () => {
     await libraryGenerator(tree, options);
     expect(shared.addGoWorkDependency).not.toHaveBeenCalled();

--- a/packages/nx-go/src/generators/library/generator.ts
+++ b/packages/nx-go/src/generators/library/generator.ts
@@ -58,6 +58,9 @@ export default async function libraryGenerator(
     projectConfiguration.targets.tidy = {
       executor: '@nx-go/nx-go:tidy',
     };
+    projectConfiguration.targets.download = {
+      executor: '@nx-go/nx-go:download',
+    };
     updateProjectConfiguration(tree, options.name, projectConfiguration);
   }
 

--- a/packages/nx-go/src/migrations/update-3.4.0/add-download-target-to-libraries-and-applications.spec.ts
+++ b/packages/nx-go/src/migrations/update-3.4.0/add-download-target-to-libraries-and-applications.spec.ts
@@ -1,0 +1,93 @@
+import * as devkit from '@nx/devkit';
+import { ProjectConfiguration, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { TargetConfiguration } from 'nx/src/config/workspace-json-project-json';
+import update from './add-download-target-to-libraries-and-applications';
+import { NX_PLUGIN_NAME } from '../../constants';
+import * as goBridge from '../../utils/go-bridge';
+
+jest.mock('@nx/devkit');
+
+describe('add-download-target-to-libraries-and-applications migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => (tree = createTreeWithEmptyWorkspace()));
+  afterEach(() => jest.clearAllMocks());
+
+  const createProjectMapWithTarget = (targets: {
+    [targetName: string]: Partial<TargetConfiguration>;
+  }) => new Map([['api', { root: '', targets } as ProjectConfiguration]]);
+
+  describe('when go workspace', () => {
+    beforeEach(() => {
+      jest.spyOn(goBridge, 'isGoWorkspace').mockReturnValue(true);
+    });
+
+    it('should update application / library targets with @nx-go/nx-go:download', async () => {
+      const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+      jest.spyOn(devkit, 'getProjects').mockReturnValue(
+        createProjectMapWithTarget({
+          serve: {
+            executor: `${NX_PLUGIN_NAME}:serve`,
+          },
+        })
+      );
+      await update(tree);
+      expect(updateConfig).toHaveBeenCalledWith(tree, 'api', expect.anything());
+      expect(updateConfig.mock.calls[0][2].targets.download).toEqual({
+        executor: '@nx-go/nx-go:download',
+      });
+    });
+
+    it('should update application / library target with @nx-go/nx-go:download when target already exist with custom command', async () => {
+      const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+      jest.spyOn(devkit, 'getProjects').mockReturnValue(
+        createProjectMapWithTarget({
+          serve: {
+            executor: `${NX_PLUGIN_NAME}:serve`,
+          },
+          download: {
+            executor: 'nx:run-commands',
+          },
+        })
+      );
+      await update(tree);
+      expect(updateConfig).toHaveBeenCalledWith(tree, 'api', expect.anything());
+      expect(updateConfig.mock.calls[0][2].targets.download).toEqual({
+        executor: '@nx-go/nx-go:download',
+      });
+    });
+
+    it('should not update application / library targets with @nx-go/nx-go:download when not a nx-go project', async () => {
+      const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+      jest.spyOn(devkit, 'getProjects').mockReturnValue(
+        createProjectMapWithTarget({
+          serve: {
+            executor: `@angular:serve`,
+          },
+        })
+      );
+      await update(tree);
+      expect(updateConfig).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when not a go workspace', () => {
+    beforeEach(() => {
+      jest.spyOn(goBridge, 'isGoWorkspace').mockReturnValue(false);
+    });
+
+    it('should not update application / library targets with @nx-go/nx-go:download', async () => {
+      const updateConfig = jest.spyOn(devkit, 'updateProjectConfiguration');
+      jest.spyOn(devkit, 'getProjects').mockReturnValue(
+        createProjectMapWithTarget({
+          serve: {
+            executor: `${NX_PLUGIN_NAME}:serve`,
+          },
+        })
+      );
+      await update(tree);
+      expect(updateConfig).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/nx-go/src/migrations/update-3.4.0/add-download-target-to-libraries-and-applications.ts
+++ b/packages/nx-go/src/migrations/update-3.4.0/add-download-target-to-libraries-and-applications.ts
@@ -1,0 +1,44 @@
+import {
+  formatFiles,
+  getProjects,
+  type Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { isGoWorkspace, isProjectUsingNxGo } from '../../utils';
+
+/**
+ * Add download executor to existing nx-go projects
+ *
+ * @param tree the project tree
+ */
+export default async function update(tree: Tree) {
+  // When it's not a go workspace we don't add it to any project
+  if (!isGoWorkspace(tree)) {
+    return;
+  }
+
+  const projects = getProjects(tree);
+
+  for (const [projectName, projectConfig] of projects) {
+    let shouldUpdate = false;
+
+    if (!projectConfig.targets) continue;
+    if (!isProjectUsingNxGo(projectConfig)) continue;
+
+    if (
+      !projectConfig.targets.download ||
+      projectConfig.targets.download?.executor !== '@nx-go/nx-go:download'
+    ) {
+      projectConfig.targets.download = {
+        executor: '@nx-go/nx-go:download',
+      };
+      shouldUpdate = true;
+    }
+
+    if (shouldUpdate) {
+      updateProjectConfiguration(tree, projectName, projectConfig);
+    }
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
# Description

Sometimes, it is necessary to execute the `go mod download` command to sync modules from `go.mod` to the local cache. This PR adds a download target for that purpose.