### PR TITLE
feat: add module path

### DIFF
--- a/packages/nx-go/src/generators/application/generator.ts
+++ b/packages/nx-go/src/generators/application/generator.ts
@@ -61,7 +61,7 @@ export default async function applicationGenerator(
   generateFiles(tree, join(__dirname, 'files'), options.projectRoot, options);
 
   if (isGoWorkspace(tree)) {
-    createGoMod(tree, options.projectRoot, options.projectRoot);
+    createGoMod(tree, options.projectRoot, options.projectRoot, options.modulePath);
     addGoWorkDependency(tree, options.projectRoot);
     projectConfiguration.targets.tidy = {
       executor: '@nx-go/nx-go:tidy',

--- a/packages/nx-go/src/generators/application/schema.json
+++ b/packages/nx-go/src/generators/application/schema.json
@@ -34,6 +34,10 @@
       "description": "Skip formatting files.",
       "default": false,
       "x-priority": "internal"
+    },
+    "modulePath": {
+      "type": "string",
+      "description": "The module path of the library. (i.e. github.com/org/repo)"
     }
   },
   "required": ["name"]

--- a/packages/nx-go/src/generators/library/generator.ts
+++ b/packages/nx-go/src/generators/library/generator.ts
@@ -53,7 +53,7 @@ export default async function libraryGenerator(
   });
 
   if (isGoWorkspace(tree)) {
-    createGoMod(tree, options.projectRoot, options.projectRoot);
+    createGoMod(tree, options.projectRoot, options.projectRoot, options.modulePath);
     addGoWorkDependency(tree, options.projectRoot);
     projectConfiguration.targets.tidy = {
       executor: '@nx-go/nx-go:tidy',

--- a/packages/nx-go/src/generators/library/schema.json
+++ b/packages/nx-go/src/generators/library/schema.json
@@ -34,6 +34,10 @@
       "description": "Skip formatting files.",
       "default": false,
       "x-priority": "internal"
+    },
+    "modulePath": {
+      "type": "string",
+      "description": "The module path of the library. (i.e. github.com/org/repo)"
     }
   },
   "required": ["name"]

--- a/packages/nx-go/src/utils/go-bridge.ts
+++ b/packages/nx-go/src/utils/go-bridge.ts
@@ -106,11 +106,12 @@ export const parseGoList = (
 export const createGoMod = (
   tree: Tree,
   name: string,
-  folder?: string
+  folder?: string,
+  modulePath?: string,
 ): void => {
   const filePath = folder ? join(folder, GO_MOD_FILE) : GO_MOD_FILE;
   if (!tree.exists(filePath)) {
-    tree.write(filePath, `module ${name}\n\ngo ${getGoShortVersion()}\n`);
+    tree.write(filePath, `module ${modulePath ? join(modulePath, name) : name}\n\ngo ${getGoShortVersion()}\n`);
   }
 };
 

--- a/packages/nx-go/src/utils/normalize-options.ts
+++ b/packages/nx-go/src/utils/normalize-options.ts
@@ -16,6 +16,7 @@ export interface GeneratorSchema {
   projectNameAndRootFormat?: ProjectNameAndRootFormat;
   tags?: string;
   skipFormat?: boolean;
+  modulePath?: string;
 }
 
 export interface GeneratorNormalizedSchema extends GeneratorSchema {


### PR DESCRIPTION
This PR adds in the ability to have a module path within the generator.  

For example, you can set the module name to github.com/csechrist/demo-project, and it will generate a go.mod file with the module of github.com/csechrist/demo-project/<pathName>

