### PR TITLE
feat: add the possibility for a custom extension

### DIFF
--- a/packages/nx-go/src/executors/build/executor.spec.ts
+++ b/packages/nx-go/src/executors/build/executor.spec.ts
@@ -15,6 +15,13 @@ jest.mock('../../utils', () => {
 const options: BuildExecutorSchema = {
   main: 'apps/project/main.go',
   env: { hello: 'world' },
+  extension: 'inherit',
+};
+
+const customExt: BuildExecutorSchema = {
+  main: 'apps/project/main.go',
+  env: { hello: 'world' },
+  extension: '.whatever',
 };
 
 const context: ExecutorContext = {
@@ -33,6 +40,23 @@ describe('Build Executor', () => {
     async ({ platform, outputPath }) => {
       Object.defineProperty(process, 'platform', { value: platform });
       const output = await executor(options, context);
+      expect(output.success).toBeTruthy();
+      expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
+        ['build', '-o', outputPath, 'apps/project/main.go'],
+        { cwd: 'current-dir', env: { hello: 'world' } }
+      );
+    }
+  );
+
+  it.each`
+    platform   | outputPath
+    ${'win32'} | ${'dist/apps/project.whatever'}
+    ${'linux'} | ${'dist/apps/project.whatever'}
+  `(
+    'should execute build command on platform $platform with custom extension',
+    async ({ platform, outputPath }) => {
+      Object.defineProperty(process, 'platform', { value: platform });
+      const output = await executor(customExt, context);
       expect(output.success).toBeTruthy();
       expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
         ['build', '-o', outputPath, 'apps/project/main.go'],

--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -30,7 +30,11 @@ const buildParams = (
   return [
     'build',
     '-o',
-    buildOutputPath(extractProjectRoot(context), options.outputPath),
+    buildOutputPath(
+      extractProjectRoot(context),
+      options.extension,
+      options.outputPath
+    ),
     ...buildStringFlagIfValid('-buildmode', options.buildMode),
     ...(options.flags ?? []),
     options.main,
@@ -43,9 +47,17 @@ const buildParams = (
  * @param projectRoot project root
  * @param customPath custom path to use first
  */
-const buildOutputPath = (projectRoot: string, customPath?: string): string => {
-  const extension = process.platform === 'win32' ? '.exe' : '';
-  return (customPath ?? `dist/${projectRoot}`) + extension;
+const buildOutputPath = (
+  projectRoot: string,
+  extension: BuildExecutorSchema['extension'],
+  customPath?: string
+): string => {
+  let ext = process.platform === 'win32' ? '.exe' : '';
+
+  if (extension !== 'inherit') {
+    ext = extension;
+  }
+  return (customPath ?? `dist/${projectRoot}`) + ext;
 };
 
 /**

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -5,4 +5,5 @@ export interface BuildExecutorSchema {
   buildMode?: string;
   env?: { [key: string]: string };
   flags?: string[];
+  extension: 'inherit' | (string & {}); // eslint-disable-line
 }

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -40,6 +40,11 @@
         "type": "string"
       },
       "description": "Flags to pass to the go compiler"
+    },
+    "extension": {
+      "type": "string",
+      "default": "inherit",
+      "description": "The extension of the output file. By default, it will make an extension based on the OS"
     }
   },
   "required": ["main"]


### PR DESCRIPTION
As I'm trying to use this build step to build my go packages, I need them to be in binary format but on windows I keep getting the `.exe` extension. I created this implementaiton so I can use it as an option to pass in:
```
{
   "extension": ""
}
```