### PR TITLE
feat: make "main" option optional in build and serve executors

### DIFF
--- a/packages/nx-go-e2e/src/nx-go.spec.ts
+++ b/packages/nx-go-e2e/src/nx-go.spec.ts
@@ -64,7 +64,7 @@ describe('nx-go', () => {
     it('should build the application', async () => {
       const result = await runNxCommandAsync(`build ${appName}`);
       expect(result.stdout).toContain(
-        `Executing command: go build -o ../dist/${appName}${ext} main.go`
+        `Executing command: go build -o ../dist/${appName}${ext} .`
       );
       expect(() => checkFilesExist(`dist/${appName}${ext}`)).not.toThrow();
     });
@@ -73,6 +73,21 @@ describe('nx-go', () => {
       const result = await runNxCommandAsync(`build ${appName}`, {
         cwd: tmpProjPath(appName),
       });
+      expect(result.stdout).toContain(
+        `Executing command: go build -o ../dist/${appName}${ext} .`
+      );
+      expect(() => checkFilesExist(`dist/${appName}${ext}`)).not.toThrow();
+    });
+
+    it('should build the application with specifying main file', async () => {
+      // Update project.json to add main option
+      updateFile(`${appName}/project.json`, (content) => {
+        const json = JSON.parse(content);
+        json.targets.build.options = { main: 'main.go' };
+        return JSON.stringify(json);
+      });
+
+      const result = await runNxCommandAsync(`build ${appName}`);
       expect(result.stdout).toContain(
         `Executing command: go build -o ../dist/${appName}${ext} main.go`
       );
@@ -124,6 +139,18 @@ describe('nx-go', () => {
   });
 
   it('should serve the application', async () => {
+    const result = await runNxCommandAsync(`serve ${appName}`);
+    expect(result.stdout).toContain(`Executing command: go run .`);
+  });
+
+  it('should serve the application with specifying main file', async () => {
+    // Update project.json to add main option
+    updateFile(`${appName}/project.json`, (content) => {
+      const json = JSON.parse(content);
+      json.targets.serve.options = { main: 'main.go' };
+      return JSON.stringify(json);
+    });
+
     const result = await runNxCommandAsync(`serve ${appName}`);
     expect(result.stdout).toContain(`Executing command: go run main.go`);
   });

--- a/packages/nx-go/src/executors/build/executor.spec.ts
+++ b/packages/nx-go/src/executors/build/executor.spec.ts
@@ -88,4 +88,16 @@ describe('Build Executor', () => {
       expect.anything()
     );
   });
+
+  it('should default to current directory when main is not provided', async () => {
+    const optionsWithoutMain = {
+      env: { hello: 'world' },
+    };
+    const output = await executor(optionsWithoutMain, context);
+    expect(output.success).toBeTruthy();
+    expect(sharedFunctions.executeCommand).toHaveBeenCalledWith(
+      ['build', '-o', '../../dist/apps/project', '.'],
+      { cwd: 'apps/project', env: { hello: 'world' } }
+    );
+  });
 });

--- a/packages/nx-go/src/executors/build/executor.ts
+++ b/packages/nx-go/src/executors/build/executor.ts
@@ -41,7 +41,7 @@ const buildParams = (
     buildOutputPath(context, options.outputPath),
     ...buildStringFlagIfValid('-buildmode', options.buildMode),
     ...(options.flags ?? []),
-    options.main,
+    options.main ?? '.',
   ];
 };
 

--- a/packages/nx-go/src/executors/build/schema.d.ts
+++ b/packages/nx-go/src/executors/build/schema.d.ts
@@ -1,5 +1,5 @@
 export interface BuildExecutorSchema {
-  main: string;
+  main?: string;
   compiler?: 'go' | 'tinygo';
   outputPath?: string;
   buildMode?: string;

--- a/packages/nx-go/src/executors/build/schema.json
+++ b/packages/nx-go/src/executors/build/schema.json
@@ -10,8 +10,7 @@
       "type": "string",
       "description": "Path to the file containing the main() function",
       "x-completion-type": "file",
-      "x-completion-glob": "main.go",
-      "x-priority": "important"
+      "x-completion-glob": "main.go"
     },
     "compiler": {
       "type": "string",
@@ -41,6 +40,5 @@
       },
       "description": "Flags to pass to the go compiler"
     }
-  },
-  "required": ["main"]
+  }
 }

--- a/packages/nx-go/src/executors/serve/executor.spec.ts
+++ b/packages/nx-go/src/executors/serve/executor.spec.ts
@@ -76,4 +76,14 @@ describe('Serve Executor', () => {
       cwd: 'apps/project',
     });
   });
+
+  it('should default to current directory when main is not provided', async () => {
+    const spyExecute = jest.spyOn(commonFunctions, 'executeCommand');
+    const optionsWithoutMain = { args: ['--help'] };
+    const output = await executor(optionsWithoutMain, context);
+    expect(output.success).toBeTruthy();
+    expect(spyExecute).toHaveBeenCalledWith(['run', '.', '--help'], {
+      cwd: 'apps/project',
+    });
+  });
 });

--- a/packages/nx-go/src/executors/serve/executor.ts
+++ b/packages/nx-go/src/executors/serve/executor.ts
@@ -1,9 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
-import {
-  executeCommand,
-  extractProjectRoot,
-  resolveWorkingDirectory,
-} from '../../utils';
+import { executeCommand, resolveWorkingDirectory } from '../../utils';
 import { ServeExecutorSchema } from './schema';
 
 /**
@@ -17,8 +13,7 @@ export default async function runExecutor(
   context: ExecutorContext
 ) {
   const cwd = options.cwd ?? resolveWorkingDirectory(context);
-  const directory = options.cwd ?? extractProjectRoot(context);
-  const mainFile = options.main.replace(`${directory}/`, '');
+  const mainFile = options.main ?? '.';
   return executeCommand(
     ['run', ...(options.flags ?? []), mainFile, ...(options.args ?? [])],
     { executable: options.cmd, cwd }

--- a/packages/nx-go/src/executors/serve/schema.d.ts
+++ b/packages/nx-go/src/executors/serve/schema.d.ts
@@ -1,5 +1,5 @@
 export interface ServeExecutorSchema {
-  main: string;
+  main?: string;
   cmd?: string;
   cwd?: string;
   args?: string[];

--- a/packages/nx-go/src/executors/serve/schema.json
+++ b/packages/nx-go/src/executors/serve/schema.json
@@ -9,8 +9,7 @@
       "type": "string",
       "description": "Path to the file containing the main() function",
       "x-completion-type": "file",
-      "x-completion-glob": "main.go",
-      "x-priority": "important"
+      "x-completion-glob": "main.go"
     },
     "cmd": {
       "type": "string",
@@ -37,6 +36,5 @@
       },
       "description": "Flags to pass to the go compiler"
     }
-  },
-  "required": ["main"]
+  }
 }

--- a/packages/nx-go/src/generators/application/generator.ts
+++ b/packages/nx-go/src/generators/application/generator.ts
@@ -19,15 +19,9 @@ import type { ApplicationGeneratorSchema } from './schema';
 export const defaultTargets: { [targetName: string]: TargetConfiguration } = {
   build: {
     executor: '@nx-go/nx-go:build',
-    options: {
-      main: 'main.go',
-    },
   },
   serve: {
     executor: '@nx-go/nx-go:serve',
-    options: {
-      main: 'main.go',
-    },
   },
   test: {
     executor: '@nx-go/nx-go:test',


### PR DESCRIPTION
## Description

This PR makes the `main` option optional in both `build` and `serve` executors. When `main` is not provided in the configuration, it defaults to `.` (current directory), following standard Go conventions.

## Changes

- Made `main` option optional in build executor schema
- Made `main` option optional in serve executor schema
- Default value set to `.` when not provided
- Updated related tests and documentation

## Related Issue

Closes #167

## Motivation

Currently, the `main` option is required for both `build` and `serve` executors. This is cumbersome when following standard Go conventions where the main package is in the root of the project. Users had to explicitly set `"main": "main.go"` or similar even when it could be defaulted.

This change simplifies configuration for standard Go project layouts and aligns with common Go practices.