### PR TITLE
feat: add Nx 23 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nx_version: [20.8.4, 22.4.1]
+        nx_version: [20.8.4, 23.0.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: 📥 Checkout Repo

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - ⚡ **Zero-config setup** – Automatic task inference for projects with `go.mod`
 - 💨 **Blazing-fast tasks** – Optimized caching with smart inputs and outputs
 - 🤝 **Community friendly** – Integration with recognized community projects such as [Air](https://github.com/air-verse/air)
-- 🗃️ **Reliable** – Use official Go commands in the background
+- 🗃️ **Reliable** – Use official Go commands in the background with no external dependency
 
 ## 🚀 Getting started
 
@@ -89,7 +89,7 @@ Need more customization? A [plugin configuration](./docs/options.md) is also ava
 
 | nx-go version | Nx version       |
 | ------------- | ---------------- |
-| 4.x           | 20.x to 22.x     |
+| 4.x           | 20.x to 23.x     |
 | 3.x           | 17.x to 20.x     |
 | ~~2.x~~       | ~~13.x to 16.x~~ |
 | ~~1.x~~       | ~~< 13.x~~       |
@@ -101,7 +101,7 @@ This plugin is only tested on [stable versions of Go](https://go.dev/dl/), older
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top"><a href="https://github.com/beeman"><img src="https://github.com/beeman.png" width="100" alt="Utarwyn"/><br /><b>Bram Borggreve</b></a><br />Creator</td>
+      <td align="center" valign="top"><a href="https://github.com/beeman"><img src="https://github.com/beeman.png" width="100" alt="Beeman"/><br /><b>Bram Borggreve</b></a><br />Creator</td>
       <td align="center" valign="top"><a href="https://github.com/utarwyn"><img src="https://github.com/utarwyn.png" width="100" alt="Utarwyn"/><br /><b>Maxime Malgorn</b></a><br />Maintainer</td>
     </tr>
   </tbody>

--- a/docs/executors/lint.md
+++ b/docs/executors/lint.md
@@ -4,7 +4,20 @@ Formats and lints a project using the [go fmt](https://go.dev/blog/gofmt) tool b
 
 You can use a custom linter/formatter if you want.
 
-## Exemples
+## Inferred revive linter
+
+When a Revive configuration is detected, the lint target automatically uses [revive](https://github.com/mgechev/revive) as the linter.
+
+### Conditions for automatic revive detection
+
+The revive linter is automatically configured when:
+
+- A Revive config file exists in the project root (`revive.toml` or `.revive.toml`)
+- The `revive` executable is available in PATH
+
+When these conditions are met, the lint target will automatically include Revive configuration files in its inputs and set `linter: revive` in the options.
+
+## Examples
 
 Usage with [revive](https://github.com/mgechev/revive) (need to be installed before) and a configuration file.
 
@@ -14,10 +27,7 @@ Usage with [revive](https://github.com/mgechev/revive) (need to be installed bef
     "executor": "@nx-go/nx-go:lint",
     "options": {
       "linter": "revive",
-      "args": [
-        "-config",
-        "revive.toml"
-      ]
+      "args": ["-config", "revive.toml"]
     }
   }
 }

--- a/packages/nx-go/package.json
+++ b/packages/nx-go/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/nx-go/nx-go/issues"
   },
   "dependencies": {
-    "@nx/devkit": ">= 20 < 23",
+    "@nx/devkit": ">= 20 < 24",
     "tslib": "^2.3.0"
   },
   "type": "commonjs",


### PR DESCRIPTION
## Description

Add support for Nx 23 to the nx-go plugin. This PR extends the supported Nx versions to include Nx 23.0.0 and updates the DevKit dependency constraints accordingly.

### Changes

- **CI Matrix**: Updated the GitHub Actions CI workflow to test against Nx 23.0.0 (previously tested Nx 22.4.1)
- **DevKit Dependency**: Expanded `@nx/devkit` version constraint from `>= 20 < 23` to `>= 20 < 24` to support Nx 23.x

## Related Issue(s)

Fixes #184 

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Breaking Changes

N/A

## Additional Notes

This change maintains backward compatibility with Nx 20 and 22 while adding support for the latest Nx 23 release.