### PR TITLE
fix: revert Nx 23 devkit which contains breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **First-class support of [Go](https://go.dev) in a [Nx](https://nx.dev) workspace**
 
 [![GitHub release](https://img.shields.io/github/v/release/nx-go/nx-go)](https://github.com/nx-go/nx-go/releases/latest)
-[![Nx version](https://img.shields.io/npm/dependency-version/%40nx-go%2Fnx-go/%40nx%2Fdevkit?label=Nx&logo=nx)](https://nx.dev)
+[![Nx version](https://img.shields.io/badge/Nx-20.x%20to%2023.x-blue?logo=nx&label=Nx)](https://nx.dev)
 [![npm Downloads](https://img.shields.io/npm/dt/@nx-go/nx-go?color=eb2f06&logo=npm)](https://npmjs.com/package/@nx-go/nx-go)
 [![LICENSE](https://img.shields.io/github/license/nx-go/nx-go)](https://github.com/nx-go/nx-go/blob/main/LICENSE)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=nx-go_nx-go&metric=alert_status)](https://sonarcloud.io/dashboard?id=nx-go_nx-go)

--- a/packages/nx-go/package.json
+++ b/packages/nx-go/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/nx-go/nx-go/issues"
   },
   "dependencies": {
-    "@nx/devkit": ">= 20 < 24",
+    "@nx/devkit": ">= 20 < 23",
     "tslib": "^2.3.0"
   },
   "type": "commonjs",


### PR DESCRIPTION
## Description

Updated the @nx/devkit dependency constraint to prevent compatibility issues with Nx 23.

I apologize - this is a use case I did not see during development and in CI because the plugin was using the wrong devkit version. This change fixes the version constraint to properly support the version range.

## Changes

- Updated `@nx/devkit` dependency from `>= 20 < 24` to `>= 20 < 23` 

## Limitations

Please note that with this change, the plugin will still use Nx 22 devkit even when Nx 23 is present in the user's workspace. This is not ideal, but since devkit 23 includes breaking changes on exports, support for it will only be added in the next major version of nx-go.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

## Breaking Changes

N/A

## Additional Notes

This resolves compatibility issues that were not caught earlier due to incorrect devkit version in the development environment.